### PR TITLE
HOTFIX: fix bad imports in minimock

### DIFF
--- a/ledger-core/v2/Makefile
+++ b/ledger-core/v2/Makefile
@@ -62,7 +62,7 @@ pre-build: install-build-tools generate regen-builtin ## install dependencies, (
 
 .PHONY: generate
 generate: ## run go generate
-	go generate -x $(ALL_PACKAGES)
+	GOFLAGS="" go generate -x $(ALL_PACKAGES)
 
 .PHONY: vendor
 vendor: ## update vendor dependencies

--- a/ledger-core/v2/go.mod
+++ b/ledger-core/v2/go.mod
@@ -15,15 +15,13 @@ require (
 	github.com/fsnotify/fsnotify v1.4.7
 	github.com/getkin/kin-openapi v0.2.1-0.20191211203508-0d9caf80ada6
 	github.com/gogo/protobuf v1.2.1
-	github.com/gojuno/minimock v1.9.2 // indirect
-	github.com/gojuno/minimock/v3 v3.0.5
+	github.com/gojuno/minimock/v3 v3.0.6
 	github.com/golang/protobuf v1.3.2
 	github.com/google/gofuzz v1.0.0
 	github.com/google/gops v0.3.6
 	github.com/grpc-ecosystem/grpc-gateway v1.9.6
 	github.com/hashicorp/golang-lru v0.5.3
 	github.com/insolar/component-manager v0.2.1-0.20191028200619-751a91771d2f
-	github.com/insolar/go-actors v0.0.0-20190805151516-2fcc7bfc8ff9 // indirect
 	github.com/insolar/rpc v1.2.2-0.20190812143745-c27e1d218f1f
 	github.com/insolar/x-crypto v0.0.0-20191031140942-75fab8a325f6
 	github.com/jbenet/go-base58 v0.0.0-20150317085156-6237cf65f3a6
@@ -55,12 +53,11 @@ require (
 	github.com/uber/jaeger-lib v2.2.0+incompatible // indirect
 	github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8
 	go.opencensus.io v0.22.0
-	golang.org/x/crypto v0.0.0-20190820162420-60c769a6c586
-	golang.org/x/net v0.0.0-20190827160401-ba9fcec4b297
-	golang.org/x/sync v0.0.0-20190423024810-112230192c58
+	golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550
+	golang.org/x/net v0.0.0-20200226121028-0de0cce0169b
+	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e
 	golang.org/x/sys v0.0.0-20190826190057-c7b8b68b1456
-	golang.org/x/tools v0.0.0-20190827205025-b29f5f60c37a
-	gonum.org/v1/gonum v0.0.0-20191018104224-74cb7b153f2c // indirect
+	golang.org/x/tools v0.0.0-20200312153518-5e2df02acb1e
 	google.golang.org/genproto v0.0.0-20190819201941-24fa4b261c55
 	google.golang.org/grpc v1.21.0
 	gopkg.in/yaml.v2 v2.2.7

--- a/ledger-core/v2/network/consensus/gcpv2/api/transport/full_introduction_reader_mock.go
+++ b/ledger-core/v2/network/consensus/gcpv2/api/transport/full_introduction_reader_mock.go
@@ -9,10 +9,10 @@ import (
 
 	"github.com/gojuno/minimock/v3"
 	"github.com/insolar/assured-ledger/ledger-core/v2/insolar"
+	"github.com/insolar/assured-ledger/ledger-core/v2/network/consensus/common/endpoints"
 	"github.com/insolar/assured-ledger/ledger-core/v2/network/consensus/gcpv2/api/member"
 	"github.com/insolar/assured-ledger/ledger-core/v2/pulse"
 	"github.com/insolar/assured-ledger/ledger-core/v2/vanilla/cryptkit"
-	"github.com/insolar/insolar/network/consensus/common/endpoints"
 )
 
 // FullIntroductionReaderMock implements FullIntroductionReader

--- a/ledger-core/v2/network/consensus/gcpv2/api/transport/packet_readers.go
+++ b/ledger-core/v2/network/consensus/gcpv2/api/transport/packet_readers.go
@@ -151,6 +151,8 @@ type BriefIntroductionReader interface {
 }
 
 //go:generate minimock -i github.com/insolar/assured-ledger/ledger-core/v2/network/consensus/gcpv2/api/transport.FullIntroductionReader -o . -s _mock.go -g
+//go:generate goimports -w ./full_introduction_reader_mock.go
+
 type FullIntroductionReader interface {
 	profiles.CandidateProfile
 }


### PR DESCRIPTION
Minimock generated on `transport.FullIntroductionReader`
for some reason adds weird cyclic imports.
I've added `goimports` run after minimock generation to fix this.
Goimports fails if runs with '-mod=vendor' go flag. So I had to
Add GOFLAGS="" in `generate` target in Makefile.