### PR TITLE
NOISSUE: skip ledger-v2 directory from test runs

### DIFF
--- a/ledger-core/v2/Makefile.testing
+++ b/ledger-core/v2/Makefile.testing
@@ -2,14 +2,15 @@ TEST_COUNT      ?= 1
 FUNCTEST_COUNT  ?= 1
 GOTEST          ?= go test
 TEST_ARGS       ?= -timeout 1200s
-TESTED_PACKAGES ?= $(shell go list ${ALL_PACKAGES} | grep -v "${MOCKS_PACKAGE}")
+TESTED_PACKAGES ?= $(shell go list ${ALL_PACKAGES} | grep -v "${MOCKS_PACKAGE}" | grep -v /ledger-v2/)
+PACKAGES ?= $(shell go list ./... | grep -v /ledger-v2/)
 
 .PHONY: test_all
 test_all: test_unit test_func test_slow ## run all tests (unit, func, slow)
 
 .PHONY: test_unit
 test_unit: ## run all unit tests
-	CGO_ENABLED=1 $(GOTEST) -count=1 $(TEST_ARGS) $(ALL_PACKAGES)
+	$(GOTEST) -count=1 $(TEST_ARGS) $(PACKAGES)
 
 .PHONY: test_func
 test_func: ## run functest FUNCTEST_COUNT times
@@ -23,7 +24,7 @@ test_func_race: ## run functest 10 times with -race flag
 
 .PHONY: test_slow
 test_slow: ## run tests with slowtest tag
-	CGO_ENABLED=1 $(GOTEST) -count=1 $(TEST_ARGS) -tags slowtest ./...
+	$(GOTEST) -count=1 $(TEST_ARGS) -tags slowtest $(PACKAGES)
 
 .PHONY: test_with_coverage
 test_with_coverage: $(ARTIFACTS_DIR) ## run unit tests with generation of coverage file


### PR DESCRIPTION
skipped ledger-v2 directory from unit and integration tests run