### PR TITLE
OPS-134: add jira_login to git-tag-handler job

### DIFF
--- a/.github/workflows/tag_processing.yaml
+++ b/.github/workflows/tag_processing.yaml
@@ -16,5 +16,6 @@ jobs:
         env:
           SLACK_CHANNEL: notify-platform
           SLACK_API_TOKEN: ${{ secrets.SLACK_API_TOKEN }}
+          JIRA_LOGIN: ${{ secrets.JIRA_LOGIN }}
           JIRA_PASSWORD: ${{ secrets.JIRA_PASSWORD }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Add env:JIRA_LOGIN to git-tag-handler job