### PR TITLE
NOISSUE: increase golangci timeout

### DIFF
--- a/ledger-core/v2/.golangci.yml
+++ b/ledger-core/v2/.golangci.yml
@@ -1,5 +1,6 @@
 run:
   tests: false
+  timeout: 5m
   skip-dirs:
     - application/contract/
     - application/proxy/


### PR DESCRIPTION
increase golangci timeout because of big code base it exceeds default 1m