### PR TITLE
PLAT-238: Don't change pulse in insolar net

### DIFF
--- a/ledger-core/v2/application/cmd/main/main.go
+++ b/ledger-core/v2/application/cmd/main/main.go
@@ -1,0 +1,6 @@
+// Copyright 2020 Insolar Network Ltd.
+// All rights reserved.
+// This material is licensed under the Insolar License version 1.0,
+// available at https://github.com/insolar/assured-ledger/blob/master/LICENSE.md.
+
+package main

--- a/ledger-core/v2/application/cmd/main/main.go
+++ b/ledger-core/v2/application/cmd/main/main.go
@@ -1,6 +1,0 @@
-// Copyright 2020 Insolar Network Ltd.
-// All rights reserved.
-// This material is licensed under the Insolar License version 1.0,
-// available at https://github.com/insolar/assured-ledger/blob/master/LICENSE.md.
-
-package main

--- a/ledger-core/v2/application/testutils/launchnet/launchnet.go
+++ b/ledger-core/v2/application/testutils/launchnet/launchnet.go
@@ -420,7 +420,7 @@ func runPulsar() error {
 func waitForNet() error {
 	err := waitForNetworkState(insolar.WaitPulsar)
 	if err != nil {
-		return errors.Wrap(err, "Can't for NetworkState "+insolar.WaitPulsar.String())
+		return errors.Wrap(err, "Can't wait for NetworkState "+insolar.WaitPulsar.String())
 	}
 
 	err = runPulsar()
@@ -430,7 +430,7 @@ func waitForNet() error {
 
 	err = waitForNetworkState(insolar.CompleteNetworkState)
 	if err != nil {
-		return errors.Wrap(err, "Can't for NetworkState "+insolar.WaitPulsar.String())
+		return errors.Wrap(err, "Can't wait for NetworkState "+insolar.CompleteNetworkState.String())
 	}
 
 	return nil

--- a/ledger-core/v2/cmd/pulsard/main.go
+++ b/ledger-core/v2/cmd/pulsard/main.go
@@ -115,6 +115,10 @@ func main() {
 		}
 		// it's required since pulse is sent in goroutine
 		time.Sleep(time.Second * 10)
+		err = cm.Stop(ctx)
+		if err != nil {
+			inslog.Error(err)
+		}
 		return
 	}
 

--- a/ledger-core/v2/cmd/pulsard/main.go
+++ b/ledger-core/v2/cmd/pulsard/main.go
@@ -38,12 +38,14 @@ import (
 
 type inputParams struct {
 	configPath string
+	oneShot    bool
 }
 
 func parseInputParams() inputParams {
 	var rootCmd = &cobra.Command{Use: "pulsard --config=<path to config>"}
 	var result inputParams
 	rootCmd.Flags().StringVarP(&result.configPath, "config", "c", "", "path to config file")
+	rootCmd.Flags().BoolVarP(&result.oneShot, "one-shot", "o", false, "send one pulse and die")
 	rootCmd.AddCommand(version.GetCommand("pulsard"))
 	err := rootCmd.Execute()
 	if err != nil {
@@ -104,6 +106,18 @@ func main() {
 	}
 
 	cm, server := initPulsar(ctx, pCfg)
+
+	if params.oneShot {
+		nextPulseNumber := pulse.OfNow()
+		err := server.Send(ctx, nextPulseNumber)
+		if err != nil {
+			panic(err)
+		}
+		// it's required since pulse is sent in goroutine
+		time.Sleep(time.Second * 10)
+		return
+	}
+
 	pulseTicker := runPulsar(ctx, server, pCfg.Pulsar)
 
 	defer func() {

--- a/ledger-core/v2/configuration/hostnetwork.go
+++ b/ledger-core/v2/configuration/hostnetwork.go
@@ -17,12 +17,13 @@ type Transport struct {
 
 // HostNetwork holds configuration for HostNetwork
 type HostNetwork struct {
-	Transport           Transport
-	MinTimeout          int   // bootstrap timeout min
-	MaxTimeout          int   // bootstrap timeout max
-	TimeoutMult         int   // bootstrap timout multiplier
-	SignMessages        bool  // signing a messages if true
-	HandshakeSessionTTL int32 // ms
+	Transport            Transport
+	MinTimeout           int   // bootstrap timeout min
+	MaxTimeout           int   // bootstrap timeout max
+	TimeoutMult          int   // bootstrap timout multiplier
+	SignMessages         bool  // signing a messages if true
+	HandshakeSessionTTL  int32 // ms
+	PulseWatchdogTimeout int32 // seconds
 }
 
 // NewHostNetwork creates new default HostNetwork configuration
@@ -31,11 +32,12 @@ func NewHostNetwork() HostNetwork {
 	transport := Transport{Protocol: "TCP", Address: "127.0.0.1:0"}
 
 	return HostNetwork{
-		Transport:           transport,
-		MinTimeout:          10,
-		MaxTimeout:          2000,
-		TimeoutMult:         2,
-		SignMessages:        false,
-		HandshakeSessionTTL: 5000,
+		Transport:            transport,
+		MinTimeout:           10,
+		MaxTimeout:           2000,
+		TimeoutMult:          2,
+		SignMessages:         false,
+		HandshakeSessionTTL:  5000,
+		PulseWatchdogTimeout: 30,
 	}
 }

--- a/ledger-core/v2/go.mod
+++ b/ledger-core/v2/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/golang/protobuf v1.3.2
 	github.com/google/gofuzz v1.0.0
 	github.com/google/gops v0.3.6
-	github.com/google/uuid v1.1.1
+	github.com/google/uuid v1.1.1 // indirect
 	github.com/grpc-ecosystem/grpc-gateway v1.9.6
 	github.com/hashicorp/golang-lru v0.5.3
 	github.com/insolar/component-manager v0.2.1-0.20191028200619-751a91771d2f

--- a/ledger-core/v2/network/options.go
+++ b/ledger-core/v2/network/options.go
@@ -45,6 +45,6 @@ func ConfigureOptions(conf configuration.Configuration) *Options {
 		PacketTimeout:        15 * time.Second,
 		AckPacketTimeout:     5 * time.Second,
 		BootstrapTimeout:     90 * time.Second,
-		PulseWatchdogTimeout: 30 * time.Second,
+		PulseWatchdogTimeout: time.Duration(config.PulseWatchdogTimeout) * time.Second,
 	}
 }

--- a/ledger-core/v2/scripts/generate_insolar_configs.go
+++ b/ledger-core/v2/scripts/generate_insolar_configs.go
@@ -241,6 +241,8 @@ func newDefaultInsolardConfig() configuration.Configuration {
 		cfg := configuration.NewConfiguration()
 		defaultInsloardConf = &cfg
 	}
+
+	defaultInsloardConf.Host.PulseWatchdogTimeout = 2592000 // one month
 	return *defaultInsloardConf
 }
 

--- a/ledger-core/v2/scripts/insolard/launchnet.sh
+++ b/ledger-core/v2/scripts/insolard/launchnet.sh
@@ -176,6 +176,8 @@ create_required_dirs()
     mkdir -p ${DISCOVERY_NODES_DATA}certs
     mkdir -p ${CONFIGS_DIR}
 
+    mkdir -p ${PULSAR_DATA_DIR}
+
     mkdir -p ${INSGORUND_LOGS}
     touch $INSGORUND_PORT_FILE
     { set +x; } 2>/dev/null
@@ -305,7 +307,7 @@ process_input_params()
     # it must be manually reset between multiple calls to getopts
     # within the same shell invocation if a new set of parameters is to be used
     OPTIND=1
-    while getopts "h?ngblwC" opt; do
+    while getopts "h?ngblwpC" opt; do
         case "$opt" in
         h|\?)
             usage
@@ -330,6 +332,9 @@ process_input_params()
             ;;
         w)
             watch_pulse=false
+            ;;
+        p)
+            run_pulsar=false
             ;;
         C)
             generate_insolard_configs
@@ -441,19 +446,24 @@ bootstrap()
 
 run_insgorund=true
 watch_pulse=true
+run_pulsar=true
 check_working_dir
 process_input_params $@
 
 kill_all
 trap 'stop_all' INT TERM EXIT
 
-echo "start pulsar ..."
-echo "   log: ${LAUNCHNET_LOGS_DIR}pulsar_output.log"
-set -x
-mkdir -p ${PULSAR_DATA_DIR}
-${PULSARD} -c ${PULSAR_CONFIG} &> ${LAUNCHNET_LOGS_DIR}pulsar_output.log &
-{ set +x; } 2>/dev/null
-echo "pulsar log: ${LAUNCHNET_LOGS_DIR}pulsar_output.log"
+if [[ "$run_pulsar" == "true" ]]
+then
+    echo "start pulsar ..."
+    echo "   log: ${LAUNCHNET_LOGS_DIR}pulsar_output.log"
+    set -x
+    ${PULSARD} -c ${PULSAR_CONFIG} &> ${LAUNCHNET_LOGS_DIR}pulsar_output.log &
+    { set +x; } 2>/dev/null
+    echo "pulsar log: ${LAUNCHNET_LOGS_DIR}pulsar_output.log"
+else
+    echo "Skip launching of pulsar"
+fi
 
 launch_keeperd
 


### PR DESCRIPTION
…luanch pulsar with option --one-shot. 3. Increase PulseWatchdogTimeout up to 1 month

<!--
Please make sure you've read and understood our contributing guidelines;

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
1. Func tests run luanchnet.sh without pulsar. 
2. Func tests run pulsar with option --one-shot. 
3. Increase PulseWatchdogTimeout up to 1 month to prevent crash of nodes

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
