### PR TITLE
NOISSUE: fix ls-tools.go

### DIFF
--- a/ledger-core/v2/scripts/build/ls-tools.go
+++ b/ledger-core/v2/scripts/build/ls-tools.go
@@ -1,10 +1,10 @@
+//usr/bin/env go run -mod=vendor "$0" "$@"; exit "$?"
+// ls-tools.go - go script extract tools imports from tools.go
+
 // Copyright 2020 Insolar Network Ltd.
 // All rights reserved.
 // This material is licensed under the Insolar License version 1.0,
 // available at https://github.com/insolar/assured-ledger/blob/master/LICENSE.md.
-
-//usr/bin/env go run -mod=vendor "$0" "$@"; exit "$?"
-// ls-tools.go - go script extract tools imports from tools.go
 
 // +build tools
 


### PR DESCRIPTION
ls-tools.go is used as a script from Makefile.