### PR TITLE
PLAT-292: fix some problems with data race and `checkptr`

### DIFF
--- a/ledger-core/v2/Makefile
+++ b/ledger-core/v2/Makefile
@@ -32,7 +32,7 @@ LDFLAGS += -X github.com/insolar/assured-ledger/ledger-core/v2/version.BuildTime
 LDFLAGS += -X github.com/insolar/assured-ledger/ledger-core/v2/version.GitHash=${BUILD_HASH}
 
 .PHONY: all
-all: clean submodule pre-build build ## cleanup, install deps, (re)generate all code and build all binaries
+all: vendor clean submodule pre-build build ## cleanup, install deps, (re)generate all code and build all binaries
 
 include Makefile.build
 include Makefile.testing

--- a/ledger-core/v2/vanilla/reflectkit/reflect_accessor.go
+++ b/ledger-core/v2/vanilla/reflectkit/reflect_accessor.go
@@ -207,5 +207,12 @@ func FieldValueGetter(index int, fd reflect.StructField, useAddr bool, baseOffse
 }
 
 func offsetFieldGetter(v reflect.Value, fieldOffset uintptr, fieldType reflect.Type) reflect.Value {
-	return reflect.NewAt(fieldType, unsafe.Pointer(v.UnsafeAddr()+fieldOffset)).Elem()
+	// base has to be here as a separate variable because of new checkptr check in go 1.14
+	// By default it is enabled when -race flag is present.
+	// It checks the following: If the result of pointer arithmetic points into
+	// a Go heap object, one of the unsafe.Pointer-typed operands must point
+	// into the same object.
+	// See go release notes for details: https://golang.org/doc/go1.14#compiler
+	base := unsafe.Pointer(v.UnsafeAddr())
+	return reflect.NewAt(fieldType, unsafe.Pointer(uintptr(base)+fieldOffset)).Elem()
 }

--- a/ledger-core/v2/vanilla/unsafekit/byte_string_test.go
+++ b/ledger-core/v2/vanilla/unsafekit/byte_string_test.go
@@ -56,7 +56,8 @@ func TestRetentionByByteString(t *testing.T) {
 	runtime.GC()
 	time.Sleep(100 * time.Millisecond)
 	runtime.GC()
-	require.Equal(t, uint32(1), finMark)
+	fm := atomic.LoadUint32(&finMark)
+	require.Equal(t, uint32(1), fm)
 }
 
 // In accordance with unsafe Rule (6) this behavior is NOT guaranteed. Yet it is valid for gc compiler.
@@ -94,5 +95,6 @@ func TestRetentionBySlice(t *testing.T) {
 	runtime.GC()
 	time.Sleep(100 * time.Millisecond)
 	runtime.GC()
-	require.Equal(t, uint32(1), finMark)
+	fm := atomic.LoadUint32(&finMark)
+	require.Equal(t, uint32(1), fm)
 }

--- a/ledger-core/v2/vanilla/unsafekit/byte_string_test.go
+++ b/ledger-core/v2/vanilla/unsafekit/byte_string_test.go
@@ -18,6 +18,7 @@ import (
 
 // In accordance with unsafe Rule (6) this behavior is NOT guaranteed. Yet it is valid for gc compiler.
 // So one should be careful with Wrap/Unwrap operations.
+//go:nocheckptr
 func TestRetentionByByteString(t *testing.T) {
 	type testPtr [8912]byte // enforce off-stack allocation
 	b := make([]byte, 2048)
@@ -27,8 +28,8 @@ func TestRetentionByByteString(t *testing.T) {
 
 	finMark := uint32(0)
 
-	up := (*reflect.SliceHeader)(unsafe.Pointer(&b)).Data
-	runtime.SetFinalizer((*testPtr)(unsafe.Pointer(up)), func(_ *testPtr) {
+	shd := unsafe.Pointer((*reflect.SliceHeader)(unsafe.Pointer(&b)).Data)
+	runtime.SetFinalizer((*testPtr)(shd), func(_ *testPtr) {
 		atomic.StoreUint32(&finMark, 1)
 	})
 
@@ -44,7 +45,7 @@ func TestRetentionByByteString(t *testing.T) {
 	// an internal Data reference of ByteString/string
 
 	require.Equal(t, uint32(0), finMark)
-	tp := (*testPtr)(unsafe.Pointer(up))
+	tp := (*testPtr)(shd)
 	require.Equal(t, byte('A'), tp[0])
 	require.Equal(t, byte('B'), tp[1])
 	tp = nil


### PR DESCRIPTION
Since go 1.14 `checkptr` check is enabled if `-race` flag is present.

It checks the following:
1. When converting unsafe.Pointer to *T, the resulting pointer must be aligned appropriately for T.
2. If the result of pointer arithmetic points into a Go heap object, one of the unsafe.Pointer-typed operands must point into the same object.
See go release notes for details: https://golang.org/doc/go1.14#compiler

I've failed to fix TestRetentionByByteString properly so after discussion with @cyraxred we decided to skip this check in this test function.