### PR TITLE
PLAT-321 short looping fixes

### DIFF
--- a/ledger-core/v2/conveyor/sm_pulse_slot.go
+++ b/ledger-core/v2/conveyor/sm_pulse_slot.go
@@ -212,7 +212,7 @@ func (p *PulseSlotMachine) stepPresentLoop(ctx smachine.ExecutionContext) smachi
 	case !nextPollTime.IsZero():
 		return ctx.WaitAnyUntil(nextPollTime).ThenRepeat()
 	case !p.innerMachine.IsEmpty():
-		return ctx.Yield().ThenRepeat()
+		return ctx.WaitAny().ThenRepeat()
 	}
 	return ctx.WaitAny().ThenRepeat()
 }

--- a/ledger-core/v2/conveyor/smachine/slot.go
+++ b/ledger-core/v2/conveyor/smachine/slot.go
@@ -316,7 +316,7 @@ func (s *Slot) _tryStartWithID(slotID SlotID, minStepNo uint32) (isValid, isStar
 	}
 }
 
-func (s *Slot) stopWorking() (prevStepNo uint32) {
+func (s *Slot) stopWorking() {
 	for {
 		v := atomic.LoadUint64(&s.idAndStep)
 		if v&slotFlagBusy == 0 {
@@ -324,7 +324,7 @@ func (s *Slot) stopWorking() (prevStepNo uint32) {
 		}
 
 		if atomic.CompareAndSwapUint64(&s.idAndStep, v, v&^slotFlagBusy) {
-			return uint32(v >> stepIncrementShift)
+			return
 		}
 	}
 }

--- a/ledger-core/v2/conveyor/smachine/slot_machine_execute.go
+++ b/ledger-core/v2/conveyor/smachine/slot_machine_execute.go
@@ -199,8 +199,8 @@ func (m *SlotMachine) _executeSlot(slot *Slot, prevStepNo uint32, worker Attache
 	slot.slotFlags &^= slotWokenUp
 
 	var stateUpdate StateUpdate
-	wasDetached := worker.DetachableCall(func(worker DetachableSlotWorker) {
 
+	wasDetached := worker.DetachableCall(func(worker DetachableSlotWorker) {
 		for ; loopCount < loopLimit; loopCount++ {
 			canLoop := false
 			canLoop, hasSignal = worker.CanLoopOrHasSignal(loopCount)
@@ -222,7 +222,24 @@ func (m *SlotMachine) _executeSlot(slot *Slot, prevStepNo uint32, worker Attache
 			stateUpdate, sut, asyncCnt = ec.executeNextStep()
 
 			slot.addAsyncCount(asyncCnt)
-			if !sut.ShortLoop(slot, stateUpdate, uint32(loopCount)) {
+			switch {
+			case !sut.ShortLoop(slot, stateUpdate, uint32(loopCount)):
+				return
+			case !slot.canMigrateWorking(prevStepNo, true):
+				// don't short-loop no-migrate cases to avoid increase of their duration
+				return
+			}
+			if !slot.needsReleaseOnStepping(prevStepNo) {
+				continue
+			}
+			if !worker.NonDetachableCall(func(worker FixedSlotWorker) {
+				// MUST match SlotMachine.stopSlotWorking
+				released := slot._releaseAllDependency()
+				link := slot.NewLink()
+				m.activateDependants(released, link, worker)
+
+				_, prevStepNo, _ = slot._getState()
+			}) {
 				return
 			}
 		}

--- a/ledger-core/v2/conveyor/smachine/slot_machine_execute.go
+++ b/ledger-core/v2/conveyor/smachine/slot_machine_execute.go
@@ -230,6 +230,7 @@ func (m *SlotMachine) _executeSlot(slot *Slot, prevStepNo uint32, worker Attache
 				return
 			}
 			if !slot.needsReleaseOnStepping(prevStepNo) {
+				_, prevStepNo, _ = slot._getState()
 				continue
 			}
 			if !worker.NonDetachableCall(func(worker FixedSlotWorker) {

--- a/ledger-core/v2/conveyor/smachine/slot_utils.go
+++ b/ledger-core/v2/conveyor/smachine/slot_utils.go
@@ -106,8 +106,8 @@ func (s *Slot) _releaseDependency(controller DependencyController) ([]StepLink, 
 func (s *Slot) _releaseAllDependency() []StepLink {
 	dep := s.dependency
 	s.dependency = nil
-	postponed, released := dep.ReleaseAll()
 
+	postponed, released := dep.ReleaseAll()
 	released = PostponedList(postponed).PostponedActivate(released)
 	return released
 }

--- a/ledger-core/v2/virtual/execute/execute.go
+++ b/ledger-core/v2/virtual/execute/execute.go
@@ -95,6 +95,10 @@ func (s *SMExecute) prepareExecution(ctx smachine.InitializationContext) {
 func (s *SMExecute) Init(ctx smachine.InitializationContext) smachine.StateUpdate {
 	s.prepareExecution(ctx)
 
+	return ctx.Jump(s.stepTmp)
+}
+
+func (s *SMExecute) stepTmp(ctx smachine.ExecutionContext) smachine.StateUpdate {
 	return ctx.Jump(s.stepWaitObjectReady)
 }
 

--- a/ledger-core/v2/virtual/execute/execute.go
+++ b/ledger-core/v2/virtual/execute/execute.go
@@ -95,10 +95,6 @@ func (s *SMExecute) prepareExecution(ctx smachine.InitializationContext) {
 func (s *SMExecute) Init(ctx smachine.InitializationContext) smachine.StateUpdate {
 	s.prepareExecution(ctx)
 
-	return ctx.Jump(s.stepTmp)
-}
-
-func (s *SMExecute) stepTmp(ctx smachine.ExecutionContext) smachine.StateUpdate {
 	return ctx.Jump(s.stepWaitObjectReady)
 }
 


### PR DESCRIPTION
**- What I did**
- fix for short-loop messing up AcquireForThisStep, added check for sync dependencies after each short-loop
- added exclusion for non-migrate states for short-loop
- fixed unnecessary looping behavior in conveyor
