### PR TITLE
PLAT-287: Move to AddInputExt

### DIFF
--- a/ledger-core/v2/application/testwalletapi/statemachine/handler.go
+++ b/ledger-core/v2/application/testwalletapi/statemachine/handler.go
@@ -11,15 +11,13 @@ import (
 )
 
 type TestAPICall struct {
-	Payload  payload.VCallRequest
-	Response chan payload.VCallResult
+	Payload payload.VCallRequest
 }
 
 func Handler(call *TestAPICall) smachine.CreateFunc {
 	return func(ctx smachine.ConstructionContext) smachine.StateMachine {
 		return &SMTestAPICall{
 			requestPayload: call.Payload,
-			response:       call.Response,
 		}
 	}
 }

--- a/ledger-core/v2/application/testwalletapi/statemachine/statemachine.go
+++ b/ledger-core/v2/application/testwalletapi/statemachine/statemachine.go
@@ -26,8 +26,6 @@ type SMTestAPICall struct {
 	requestPayload  payload.VCallRequest
 	responsePayload payload.VCallResult
 
-	response chan payload.VCallResult
-
 	// injected arguments
 	pulseSlot     *conveyor.PulseSlot
 	messageSender *messageSenderAdapter.MessageSender
@@ -109,12 +107,7 @@ func (s *SMTestAPICall) stepSendRequest(ctx smachine.ExecutionContext) smachine.
 }
 
 func (s *SMTestAPICall) stepProcessResult(ctx smachine.ExecutionContext) smachine.StateUpdate {
-	reChan := s.response
-
-	go func() {
-		reChan <- s.responsePayload
-		close(s.response)
-	}()
+	ctx.SetDefaultTerminationResult(s.responsePayload)
 
 	return ctx.Stop()
 }

--- a/ledger-core/v2/conveyor/conveyor.go
+++ b/ledger-core/v2/conveyor/conveyor.go
@@ -26,6 +26,9 @@ type PulseEventFactoryFunc = func(pulse.Number, pulse.Range, InputEvent) (pulse.
 
 type EventInputer interface {
 	AddInput(ctx context.Context, pn pulse.Number, event InputEvent) error
+	AddInputExt(ctx context.Context, pn pulse.Number, event InputEvent,
+		createDefaults smachine.CreateDefaultValues,
+	) error
 }
 
 type PreparedState = struct{}

--- a/ledger-core/v2/virtual/integration/statereport_test.go
+++ b/ledger-core/v2/virtual/integration/statereport_test.go
@@ -84,7 +84,7 @@ func TestVirtual_VStateReport_HappyPath(t *testing.T) {
 	{
 		// send VStateRequest: save wallet
 		msg := makeVStateReportEvent(t, objectRef, rawWalletState)
-		require.NoError(t, server.AddInput(msg))
+		require.NoError(t, server.AddInput(ctx, msg))
 	}
 
 	checkBalance(t, server, objectRef, testBalance)
@@ -107,7 +107,7 @@ func TestVirtual_VStateReport_TwoStateReports(t *testing.T) {
 	{
 		// send VStateRequest: save wallet
 		msg := makeVStateReportEvent(t, objectRef, rawWalletState)
-		require.NoError(t, server.AddInput(msg))
+		require.NoError(t, server.AddInput(ctx, msg))
 	}
 
 	checkBalance(t, server, objectRef, testBalance)
@@ -115,7 +115,7 @@ func TestVirtual_VStateReport_TwoStateReports(t *testing.T) {
 	{
 		// send VStateRequest: one more time to simulate rewrite
 		msg := makeVStateReportEvent(t, objectRef, makeRawWalletState(t, 444))
-		require.NoError(t, server.AddInput(msg))
+		require.NoError(t, server.AddInput(ctx, msg))
 	}
 
 	checkBalance(t, server, objectRef, testBalance)

--- a/ledger-core/v2/virtual/integration/stateunavailable_test.go
+++ b/ledger-core/v2/virtual/integration/stateunavailable_test.go
@@ -43,6 +43,6 @@ func TestVirtual_VStateUnavailable_NoSuchObject(t *testing.T) {
 	reasons := []payload.VStateUnavailable_ReasonType{payload.Inactive, payload.Missing, payload.Unknown}
 	for _, reason := range reasons {
 		msg := makeVStateUnavailableEvent(t, objectRef, reason)
-		require.NoError(t, server.AddInput(msg))
+		require.NoError(t, server.AddInput(ctx, msg))
 	}
 }

--- a/ledger-core/v2/virtual/integration/utils/server.go
+++ b/ledger-core/v2/virtual/integration/utils/server.go
@@ -173,8 +173,8 @@ func (s *Server) ReplaceCache(cache descriptor.Cache) {
 	s.runner.Cache = cache
 }
 
-func (s *Server) AddInput(msg interface{}) error {
-	return s.virtual.AddInput(context.Background(), s.GetPulse().PulseNumber, msg)
+func (s *Server) AddInput(ctx context.Context, msg interface{}) error {
+	return s.virtual.Conveyor.AddInput(ctx, s.GetPulse().PulseNumber, msg)
 }
 
 func (s *Server) GlobalCaller() reference.Global {

--- a/ledger-core/v2/virtual/virtual.go
+++ b/ledger-core/v2/virtual/virtual.go
@@ -108,3 +108,7 @@ func (lr *Dispatcher) Stop(_ context.Context) error {
 func (lr *Dispatcher) AddInput(ctx context.Context, pulse pulse.Number, msg interface{}) error {
 	return lr.Conveyor.AddInput(ctx, pulse, msg)
 }
+
+func (lr *Dispatcher) AddInputExt(ctx context.Context, pulse pulse.Number, msg interface{}, createDefaults smachine.CreateDefaultValues) error {
+	return lr.Conveyor.AddInputExt(ctx, pulse, msg, createDefaults)
+}


### PR DESCRIPTION
1. switched to AddInputExt in testWalletAPI for guranteed behaviour of testAPI responses
2. moved to context propagation for logging purposes. 