### PR TITLE
Revert " PLAT-334: TestNewHostNetwork seems to be fixed on Windows "

### DIFF
--- a/ledger-core/v2/network/hostnetwork/hostnetwork_test.go
+++ b/ledger-core/v2/network/hostnetwork/hostnetwork_test.go
@@ -7,6 +7,7 @@ package hostnetwork
 
 import (
 	"context"
+	"runtime"
 	"sync"
 	"testing"
 	"time"
@@ -170,6 +171,10 @@ func (s *hostSuite) Stop() {
 }
 
 func TestNewHostNetwork(t *testing.T) {
+	if runtime.GOOS == "windows" { // TODO FIXME
+		t.Skip("Currently this test doesn't pass on windows")
+	}
+
 	defer leaktest.Check(t)()
 
 	s := newHostSuite(t)


### PR DESCRIPTION
Reverts insolar/assured-ledger#160