### PR TITLE
NOISSUE: Logger may fail due to incomparable error when console printer is active

### DIFF
--- a/ledger-core/v2/instrumentation/inslogger/consprint/console_printer.go
+++ b/ledger-core/v2/instrumentation/inslogger/consprint/console_printer.go
@@ -33,7 +33,7 @@ func NewConsolePrinter(w io.Writer, config Config) io.Writer {
 	}
 
 	config.Out = w
-	return closableConsoleWriter{config}
+	return &closableConsoleWriter{config}
 }
 
 var _ io.WriteCloser = &closableConsoleWriter{}


### PR DESCRIPTION
**- What I did**
* fix for occasional incomparable error when console printer is active
