### PR TITLE
PLAT-329: remove methodIsolation from heap

### DIFF
--- a/ledger-core/v2/application/builtin/contract/testwallet/testwallet.wrapper.go
+++ b/ledger-core/v2/application/builtin/contract/testwallet/testwallet.wrapper.go
@@ -494,29 +494,29 @@ func Initialize() XXX_contract.Wrapper {
 			"GetBalance": XXX_contract.Method{
 				Func: INSMETHOD_GetBalance,
 				Isolation: XXX_contract.MethodIsolation{
-					Interference: 0,
-					State:        1,
+					Interference: 1,
+					State:        2,
 				},
 			},
 			"Accept": XXX_contract.Method{
 				Func: INSMETHOD_Accept,
 				Isolation: XXX_contract.MethodIsolation{
-					Interference: 1,
-					State:        0,
+					Interference: 2,
+					State:        1,
 				},
 			},
 			"Transfer": XXX_contract.Method{
 				Func: INSMETHOD_Transfer,
 				Isolation: XXX_contract.MethodIsolation{
-					Interference: 1,
-					State:        0,
+					Interference: 2,
+					State:        1,
 				},
 			},
 			"Destroy": XXX_contract.Method{
 				Func: INSMETHOD_Destroy,
 				Isolation: XXX_contract.MethodIsolation{
-					Interference: 1,
-					State:        0,
+					Interference: 2,
+					State:        1,
 				},
 			},
 		},

--- a/ledger-core/v2/insolar/contract/virtual.go
+++ b/ledger-core/v2/insolar/contract/virtual.go
@@ -24,6 +24,10 @@ type MethodIsolation struct {
 	State        StateFlag
 }
 
+func (i MethodIsolation) IsZero() bool {
+	return i.Interference.IsZero() && i.State.IsZero()
+}
+
 // Method is a struct for Method and it's properties
 type Method struct {
 	Func      MethodFunc
@@ -51,17 +55,27 @@ type Wrapper struct {
 type StateFlag byte
 
 const (
-	CallDirty StateFlag = iota
+	_ StateFlag = iota
+	CallDirty
 	CallValidated
 
 	StateFlagCount = iota
 )
 
+func (f StateFlag) IsZero() bool {
+	return f == 0
+}
+
 type InterferenceFlag byte
 
 const (
-	CallIntolerable InterferenceFlag = iota
+	_ InterferenceFlag = iota
+	CallIntolerable
 	CallTolerable
 
 	InterferenceFlagCount = iota
 )
+
+func (f InterferenceFlag) IsZero() bool {
+	return f == 0
+}

--- a/ledger-core/v2/insolar/payload/vcallrequestflags.go
+++ b/ledger-core/v2/insolar/payload/vcallrequestflags.go
@@ -29,6 +29,9 @@ const (
 )
 
 func (f CallRequestFlags) WithInterference(t contract.InterferenceFlag) CallRequestFlags {
+	if t == 0 {
+		panic(throw.IllegalValue())
+	}
 	if t > contract.InterferenceFlagCount {
 		panic(throw.IllegalValue())
 	}
@@ -44,6 +47,9 @@ const (
 )
 
 func (f CallRequestFlags) WithState(s contract.StateFlag) CallRequestFlags {
+	if s == 0 {
+		panic(throw.IllegalValue())
+	}
 	if s > contract.StateFlagCount {
 		panic(throw.IllegalValue())
 	}

--- a/ledger-core/v2/insolar/payload/vcallrequestflags_test.go
+++ b/ledger-core/v2/insolar/payload/vcallrequestflags_test.go
@@ -28,7 +28,7 @@ func TestCallRequestFlags(t *testing.T) {
 	t.Run("tolerance", func(t *testing.T) {
 		flags := CallRequestFlags(0)
 
-		assert.Equal(t, contract.CallIntolerable, flags.GetInterference())
+		assert.Equal(t, contract.InterferenceFlag(0), flags.GetInterference())
 
 		flags = flags.WithInterference(contract.CallTolerable)
 
@@ -38,17 +38,17 @@ func TestCallRequestFlags(t *testing.T) {
 	t.Run("state", func(t *testing.T) {
 		flags := CallRequestFlags(0)
 
-		assert.Equal(t, contract.CallDirty, flags.GetState())
+		assert.Equal(t, contract.StateFlag(0), flags.GetState())
 
 		flags = flags.WithState(contract.CallValidated)
 
-		assert.Equal(t, CallRequestFlags(4), flags, "%b", flags)
+		assert.Equal(t, CallRequestFlags(8), flags, "%b", flags)
 
 		assert.Equal(t, contract.CallValidated, flags.GetState())
 
 		flags = flags.WithState(contract.CallDirty)
 
-		assert.Equal(t, CallRequestFlags(0), flags, "%b", flags)
+		assert.Equal(t, CallRequestFlags(4), flags, "%b", flags)
 
 		assert.Equal(t, contract.CallDirty, flags.GetState())
 	})
@@ -56,39 +56,39 @@ func TestCallRequestFlags(t *testing.T) {
 	t.Run("mixed", func(t *testing.T) {
 		flags := CallRequestFlags(0)
 
-		assert.Equal(t, contract.CallIntolerable, flags.GetInterference())
+		assert.Equal(t, contract.InterferenceFlag(0), flags.GetInterference())
 
-		assert.Equal(t, contract.CallDirty, flags.GetState())
+		assert.Equal(t, contract.StateFlag(0), flags.GetState())
 
 		flags = flags.WithInterference(contract.CallTolerable)
 
-		assert.Equal(t, CallRequestFlags(1), flags, "%b", flags)
+		assert.Equal(t, CallRequestFlags(2), flags, "%b", flags)
 
 		assert.Equal(t, contract.CallTolerable, flags.GetInterference())
 
-		assert.Equal(t, contract.CallDirty, flags.GetState())
+		assert.Equal(t, contract.StateFlag(0), flags.GetState())
 
 		flags = flags.WithState(contract.CallValidated)
 
-		assert.Equal(t, CallRequestFlags(5), flags, "%b", flags)
+		assert.Equal(t, CallRequestFlags(10), flags, "%b", flags)
 
 		assert.Equal(t, contract.CallTolerable, flags.GetInterference())
 
 		flags = flags.WithInterference(contract.CallIntolerable)
 
-		assert.Equal(t, CallRequestFlags(4), flags, "%b", flags)
+		assert.Equal(t, CallRequestFlags(9), flags, "%b", flags)
 
 		assert.Equal(t, contract.CallValidated, flags.GetState())
 
 		flags = flags.WithInterference(contract.CallTolerable)
 
-		assert.Equal(t, CallRequestFlags(5), flags, "%b", flags)
+		assert.Equal(t, CallRequestFlags(10), flags, "%b", flags)
 
 		assert.Equal(t, contract.CallTolerable, flags.GetInterference())
 
 		flags = flags.WithState(contract.CallDirty)
 
-		assert.Equal(t, CallRequestFlags(1), flags, "%b", flags)
+		assert.Equal(t, CallRequestFlags(6), flags, "%b", flags)
 
 		assert.Equal(t, contract.CallDirty, flags.GetState())
 	})

--- a/ledger-core/v2/virtual/execute/execute.go
+++ b/ledger-core/v2/virtual/execute/execute.go
@@ -51,7 +51,8 @@ type SMExecute struct {
 	deactivate        bool
 	run               *runner.RunState
 
-	methodIsolation *contract.MethodIsolation
+	hasMethodIsolation bool
+	methodIsolation    contract.MethodIsolation
 
 	// dependencies
 	runner        *runner.ServiceAdapter
@@ -249,25 +250,25 @@ func (s *SMExecute) stepWaitObjectReady(ctx smachine.ExecutionContext) smachine.
 
 	if isConstructor {
 		// default isolation for constructors
-		isolation := contract.ConstructorIsolation()
-		s.methodIsolation = &isolation
+		s.hasMethodIsolation = true
+		s.methodIsolation = contract.ConstructorIsolation()
 	}
 	// TODO[bigbes]: we're ready to execute here, so lets execute
 	return ctx.Jump(s.stepIsolationNegotiation)
 }
 
 func (s *SMExecute) stepIsolationNegotiation(ctx smachine.ExecutionContext) smachine.StateUpdate {
-	if s.methodIsolation == nil {
-		defer s.runner.PrepareExecutionClassify(ctx, s.execution, func(isolation contract.MethodIsolation, err error) {
+	if !s.hasMethodIsolation {
+		return s.runner.PrepareExecutionClassify(ctx, s.execution, func(isolation contract.MethodIsolation, err error) {
 			if err != nil {
 				panic(throw.W(err, "failed to classify method"))
 			}
-			s.methodIsolation = &isolation
-		}).Start()
-		return ctx.Sleep().ThenRepeat()
+			s.methodIsolation = isolation
+			s.hasMethodIsolation = true
+		}).DelayedStart().Sleep().ThenRepeat()
 	}
 
-	negotiatedIsolation, err := negotiateIsolation(*s.methodIsolation, s.execution.Isolation)
+	negotiatedIsolation, err := negotiateIsolation(s.methodIsolation, s.execution.Isolation)
 	if err != nil {
 		return ctx.Error(err)
 	}

--- a/ledger-core/v2/virtual/execute/execute_isolation_negotiation_test.go
+++ b/ledger-core/v2/virtual/execute/execute_isolation_negotiation_test.go
@@ -161,7 +161,7 @@ func Test_Execute_stepIsolationNegotiation(t *testing.T) {
 				objectCatalog:     catalog,
 				pulseSlot:         &pulseSlot,
 				objectSharedState: object.SharedStateAccessor{SharedDataLink: sharedStateData},
-				methodIsolation:   &tc.methodIsolation,
+				methodIsolation:   tc.methodIsolation,
 			}
 
 			stepChecker := testutils.NewSMStepChecker()


### PR DESCRIPTION
**- What I did**
removed methodIsolation from heap

**- How I did it**
- Reserved 0 value for flags, as discussed with @cyraxred 
- Added IsZero for flags and for contract.MethodIsolation struct
- Check methodIsolation fillin with IsZero

**- How to verify it**
run tests
