### PR TITLE
PLAT-351: activate pulse changing in network

### DIFF
--- a/ledger-core/v2/Makefile.testing
+++ b/ledger-core/v2/Makefile.testing
@@ -4,7 +4,7 @@ GOTEST          ?= go test
 TEST_ARGS       ?= -timeout 1200s
 TESTED_PACKAGES ?= $(shell go list ${ALL_PACKAGES} | grep -v "${MOCKS_PACKAGE}" | grep -v /ledger-v2/)
 PACKAGES        ?= $(shell go list ./... | grep -v /ledger-v2/)
-PULSAR_ONE_SHOT ?= TRUE
+PULSAR_ONESHOT  ?= TRUE
 
 .PHONY: test_all
 test_all: test_unit test_func test_slow ## run all tests (unit, func, slow)
@@ -21,11 +21,13 @@ test_with_coverage: ## run unit and slow tests with generation of coverage file
 
 .PHONY: test_func
 test_func: ## run functest FUNCTEST_COUNT times
+	PULSAR_ONESHOT=$(PULSAR_ONESHOT) \
+	PULSAR_PULSETIME=$(PULSAR_PULSETIME) \
 	CGO_ENABLED=1 $(GOTEST) -test.v $(TEST_ARGS) -tags "functest" ./application/functest -count=$(FUNCTEST_COUNT)
 
 .PHONY: test_func_slow
 test_func_slow: ## run functest 100 times with enabled pulse 3 sec
-	FUNCTEST_COUNT=100 PULSAR_ONE_SHOT=NO PULSAR_PULSETIME=3000 TEST_ARGS='-timeout 1200s' make test_func
+	FUNCTEST_COUNT=100 PULSAR_ONESHOT=FALSE PULSAR_PULSETIME=3000 TEST_ARGS='-timeout 1200s' make test_func
 
 .PNONY: test_func_race
 test_func_race: ## run functest 10 times with -race flag
@@ -63,6 +65,8 @@ test_func_kubernetes: ## run functest FUNCTEST_COUNT times in kubernetes cluster
 	INSOLAR_FUNC_RPC_URL="http://localhost/admin-api/rpc" \
 	INSOLAR_FUNC_KEYS_PATH="/tmp/insolar/" \
 	INSOLAR_FUNC_TESTWALLET_HOST="localhost" \
+	PULSAR_ONESHOT=$(PULSAR_ONESHOT) \
+	PULSAR_PULSETIME=$(PULSAR_PULSETIME) \
 	CGO_ENABLED=1 $(GOTEST) -test.v $(TEST_ARGS) -tags "functest" ./application/functest -count=$(FUNCTEST_COUNT)
 
 .PHONY: test_func_kubernetes_ci
@@ -71,6 +75,8 @@ test_func_kubernetes_ci: ## run functest FUNCTEST_COUNT times in kubernetes clus
 	INSOLAR_FUNC_RPC_URL="http://localhost/admin-api/rpc" \
 	INSOLAR_FUNC_KEYS_PATH="/tmp/insolar/" \
 	INSOLAR_FUNC_TESTWALLET_HOST="localhost" \
+	PULSAR_ONESHOT=$(PULSAR_ONESHOT) \
+	PULSAR_PULSETIME=$(PULSAR_PULSETIME) \
 	CGO_ENABLED=1 $(GOTEST) -test.v $(TEST_ARGS) -tags "functest" ./application/functest -count=$(FUNCTEST_COUNT)
 
 .PHONY: publish_integration_tests

--- a/ledger-core/v2/Makefile.testing
+++ b/ledger-core/v2/Makefile.testing
@@ -4,6 +4,7 @@ GOTEST          ?= go test
 TEST_ARGS       ?= -timeout 1200s
 TESTED_PACKAGES ?= $(shell go list ${ALL_PACKAGES} | grep -v "${MOCKS_PACKAGE}" | grep -v /ledger-v2/)
 PACKAGES        ?= $(shell go list ./... | grep -v /ledger-v2/)
+PULSAR_ONE_SHOT ?= TRUE
 
 .PHONY: test_all
 test_all: test_unit test_func test_slow ## run all tests (unit, func, slow)
@@ -21,6 +22,10 @@ test_with_coverage: ## run unit and slow tests with generation of coverage file
 .PHONY: test_func
 test_func: ## run functest FUNCTEST_COUNT times
 	CGO_ENABLED=1 $(GOTEST) -test.v $(TEST_ARGS) -tags "functest" ./application/functest -count=$(FUNCTEST_COUNT)
+
+.PHONY: test_func_slow
+test_func_slow: ## run functest 100 times with enabled pulse 3 sec
+	FUNCTEST_COUNT=100 PULSAR_ONE_SHOT=NO PULSAR_PULSETIME=3000 TEST_ARGS='-timeout 1200s' make test_func
 
 .PNONY: test_func_race
 test_func_race: ## run functest 10 times with -race flag

--- a/ledger-core/v2/application/testutils/launchnet/launchnet.go
+++ b/ledger-core/v2/application/testutils/launchnet/launchnet.go
@@ -234,11 +234,12 @@ func waitForNetworkState(state node.NetworkState) error {
 }
 
 func runPulsar() error {
-	pulsarCmd := exec.Command("sh", "-c", "./bin/pulsard -o -c .artifacts/launchnet/pulsar.yaml")
-	output, err := pulsarCmd.CombinedOutput()
-	fmt.Println("Pulsar launch output: ", string(output))
-
-	return errors.W(err, "failed to launch pulsar")
+	pulsarCmd := exec.Command("sh", "-c", "./bin/pulsard -c .artifacts/launchnet/pulsar.yaml")
+	if err := pulsarCmd.Start(); err != nil {
+		return errors.W(err, "failed to launch pulsar")
+	}
+	fmt.Println("Pulsar launched")
+	return nil
 }
 
 func waitForNet() error {

--- a/ledger-core/v2/cmd/pulsard/main.go
+++ b/ledger-core/v2/cmd/pulsard/main.go
@@ -35,7 +35,7 @@ import (
 	"github.com/insolar/assured-ledger/ledger-core/v2/version"
 )
 
-const PulsarOneShotEnv = "PULSAR_ONE_SHOT"
+const PulsarOneShotEnv = "PULSAR.ONESHOT"
 
 type inputParams struct {
 	configPath string
@@ -52,10 +52,6 @@ func parseInputParams() inputParams {
 	if err != nil {
 		fmt.Println("Wrong input params:", err.Error())
 	}
-	if oneShot, exists := os.LookupEnv(PulsarOneShotEnv); exists {
-		oneShot = strings.ToUpper(oneShot)
-		result.oneShot = result.oneShot || oneShot == "TRUE" || oneShot == "1" || oneShot == "YES"
-	}
 
 	return result
 }
@@ -71,6 +67,7 @@ func main() {
 	vp.AutomaticEnv()
 	vp.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
 	_ = vp.BindEnv("Pulsar.PulseTime")
+	_ = vp.BindEnv(PulsarOneShotEnv)
 	if len(params.configPath) != 0 {
 		vp.SetConfigFile(params.configPath)
 	}
@@ -83,6 +80,8 @@ func main() {
 	if err != nil {
 		global.Warn("failed to load configuration from file: ", err.Error())
 	}
+	oneShot := vp.GetBool(PulsarOneShotEnv)
+	params.oneShot = params.oneShot || oneShot
 
 	ctx := context.Background()
 	ctx, inslog := inslogger.InitNodeLogger(ctx, pCfg.Log, "", "pulsar")

--- a/ledger-core/v2/scripts/insolard/launchnet.sh
+++ b/ledger-core/v2/scripts/insolard/launchnet.sh
@@ -274,6 +274,7 @@ usage()
     echo -e "\t-b - do bootstrap only and exit, show bootstrap logs"
     echo -e "\t-l - clear all and exit"
     echo -e "\t-C - generate configs only"
+    echo -e "\t-p - start without pulsar"
     echo -e "\t-w - start without pulse watcher"
     echo -e "\t-g headless - start launchnet in headless mode"
 }


### PR DESCRIPTION
**- What I did**
New Makefile target for run test_func many times with active pulse

**- How I did it**
* Allow to pulsard read run mode and pulse time from os ENV
* Add to Makefile.testing target for run with params `FUNCTEST_COUNT=100 PULSAR_ONESHOT=FALSE PULSAR_PULSETIME=3000`

**- How to verify it**
Run `make test_func_slow`

**- Description for the changelog**
Add to pulsard ENV settings
* `PULSAR_ONESHOT` - if it have one of values `1`, `True`, `T`, `t`, `TRUE` pulsar will send one pulse to network and stop. Command line parameter `-o` set this mode too
* `PULSAR_PULSETIME` - allow override configuration file settings and set pulse time
