### PR TITLE
PLAT-379: Fix send and processing VStateReport without SMObject.descriptor

### DIFF
--- a/ledger-core/v2/virtual/execute/execute_test.go
+++ b/ledger-core/v2/virtual/execute/execute_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/insolar/assured-ledger/ledger-core/v2/testutils/gen"
 	"github.com/insolar/assured-ledger/ledger-core/v2/vanilla/longbits"
 	"github.com/insolar/assured-ledger/ledger-core/v2/virtual/object"
+	"github.com/insolar/assured-ledger/ledger-core/v2/virtual/testutils/shareddata"
 	"github.com/insolar/assured-ledger/ledger-core/v2/virtual/testutils/slotdebugger"
 )
 
@@ -142,7 +143,7 @@ func TestSMExecute_StartRequestProcessing(t *testing.T) {
 
 	{ // updateCounters after
 		execCtx := smachine.NewExecutionContextMock(mc).
-			UseSharedMock.Set(CallSharedDataAccessor).
+			UseSharedMock.Set(shareddata.CallSharedDataAccessor).
 			SetDefaultMigrationMock.Return().
 			JumpMock.Set(testutils.AssertJumpStep(t, smExecute.stepExecuteStart))
 
@@ -158,7 +159,7 @@ func TestSMExecute_StartRequestProcessing(t *testing.T) {
 
 	{ // update known requests panics
 		execCtx := smachine.NewExecutionContextMock(mc).
-			UseSharedMock.Set(CallSharedDataAccessor)
+			UseSharedMock.Set(shareddata.CallSharedDataAccessor)
 
 		checkerFunc := func() {
 			smExecute.stepStartRequestProcessing(execCtx)
@@ -208,9 +209,9 @@ func TestSMExecute_Semi_IncrementPendingCounters(t *testing.T) {
 			Sender: caller,
 		},
 	}
+	catalogWrapper := object.NewCatalogMockWrapper(mc)
 
 	{
-		catalogWrapper := object.NewCatalogMockWrapper(mc)
 		var catalog object.Catalog = catalogWrapper.Mock()
 		slotMachine.AddInterfaceDependency(&catalog)
 
@@ -218,6 +219,7 @@ func TestSMExecute_Semi_IncrementPendingCounters(t *testing.T) {
 		smObjectAccessor := object.SharedStateAccessor{SharedDataLink: sharedStateData}
 
 		catalogWrapper.AddObject(objectRef, smObjectAccessor)
+		catalogWrapper.AllowAccessMode(object.CatalogMockAccessGetOrCreate)
 	}
 
 	slotMachine.Start()
@@ -233,6 +235,7 @@ func TestSMExecute_Semi_IncrementPendingCounters(t *testing.T) {
 	require.Equal(t, uint8(1), sharedState.PotentialOrderedPendingCount)
 	require.Equal(t, uint8(0), sharedState.PotentialUnorderedPendingCount)
 
+	require.NoError(t, catalogWrapper.CheckDone())
 	mc.Finish()
 }
 
@@ -275,9 +278,9 @@ func TestSMExecute_MigrateBeforeLock(t *testing.T) {
 			Sender: caller,
 		},
 	}
+	catalogWrapper := object.NewCatalogMockWrapper(mc)
 
 	{
-		catalogWrapper := object.NewCatalogMockWrapper(mc)
 		var catalog object.Catalog = catalogWrapper.Mock()
 		slotMachine.AddInterfaceDependency(&catalog)
 
@@ -285,6 +288,7 @@ func TestSMExecute_MigrateBeforeLock(t *testing.T) {
 		smObjectAccessor := object.SharedStateAccessor{SharedDataLink: sharedStateData}
 
 		catalogWrapper.AddObject(objectRef, smObjectAccessor)
+		catalogWrapper.AllowAccessMode(object.CatalogMockAccessGetOrCreate)
 	}
 
 	slotMachine.Start()
@@ -302,6 +306,7 @@ func TestSMExecute_MigrateBeforeLock(t *testing.T) {
 
 	require.False(t, smExecute.migrationHappened)
 
+	require.NoError(t, catalogWrapper.CheckDone())
 	mc.Finish()
 }
 
@@ -344,9 +349,9 @@ func TestSMExecute_MigrateAfterLock(t *testing.T) {
 			Sender: caller,
 		},
 	}
+	catalogWrapper := object.NewCatalogMockWrapper(mc)
 
 	{
-		catalogWrapper := object.NewCatalogMockWrapper(mc)
 		var catalog object.Catalog = catalogWrapper.Mock()
 		slotMachine.AddInterfaceDependency(&catalog)
 
@@ -354,6 +359,7 @@ func TestSMExecute_MigrateAfterLock(t *testing.T) {
 		smObjectAccessor := object.SharedStateAccessor{SharedDataLink: sharedStateData}
 
 		catalogWrapper.AddObject(objectRef, smObjectAccessor)
+		catalogWrapper.AllowAccessMode(object.CatalogMockAccessGetOrCreate)
 	}
 
 	slotMachine.Start()
@@ -371,5 +377,6 @@ func TestSMExecute_MigrateAfterLock(t *testing.T) {
 
 	assert.True(t, smExecute.migrationHappened)
 
+	require.NoError(t, catalogWrapper.CheckDone())
 	mc.Finish()
 }

--- a/ledger-core/v2/virtual/handlers/vstatereport_test.go
+++ b/ledger-core/v2/virtual/handlers/vstatereport_test.go
@@ -1,0 +1,62 @@
+// Copyright 2020 Insolar Network Ltd.
+// All rights reserved.
+// This material is licensed under the Insolar License version 1.0,
+// available at https://github.com/insolar/assured-ledger/blob/master/LICENSE.md.
+
+package handlers
+
+import (
+	"testing"
+
+	"github.com/gojuno/minimock/v3"
+	"github.com/stretchr/testify/require"
+
+	"github.com/insolar/assured-ledger/ledger-core/v2/conveyor/smachine"
+	"github.com/insolar/assured-ledger/ledger-core/v2/insolar/payload"
+	"github.com/insolar/assured-ledger/ledger-core/v2/pulse"
+	"github.com/insolar/assured-ledger/ledger-core/v2/reference"
+	"github.com/insolar/assured-ledger/ledger-core/v2/testutils/gen"
+	"github.com/insolar/assured-ledger/ledger-core/v2/vanilla/longbits"
+	"github.com/insolar/assured-ledger/ledger-core/v2/virtual/object"
+	"github.com/insolar/assured-ledger/ledger-core/v2/virtual/testutils/shareddata"
+)
+
+func TestVStateReport_CreateObjectWithoutState(t *testing.T) {
+	var (
+		mc               = minimock.NewController(t)
+		pd               = pulse.NewFirstPulsarData(10, longbits.Bits256{})
+		catalog          = object.NewCatalogMockWrapper(mc)
+		smObjectID       = gen.UniqueIDWithPulse(pd.PulseNumber)
+		smGlobalRef      = reference.NewSelf(smObjectID)
+		smObject         = object.NewStateMachineObject(smGlobalRef)
+		sharedStateData  = smachine.NewUnboundSharedData(&smObject.SharedState)
+		smObjectAccessor = object.SharedStateAccessor{SharedDataLink: sharedStateData}
+	)
+
+	catalog.AddObject(smGlobalRef, smObjectAccessor)
+	catalog.AllowAccessMode(object.CatalogMockAccessGetOrCreate)
+
+	smVStateReport := SMVStateReport{
+		Payload: &payload.VStateReport{
+			Callee:                smGlobalRef,
+			UnorderedPendingCount: 1,
+			OrderedPendingCount:   1,
+			ProvidedContent:       &payload.VStateReport_ProvidedContentBody{},
+		},
+		objectCatalog: catalog.Mock(),
+	}
+
+	execCtx := smachine.NewExecutionContextMock(mc).
+		UseSharedMock.Set(shareddata.CallSharedDataAccessor).
+		StopMock.Return(smachine.StateUpdate{})
+
+	require.Equal(t, object.Unknown, smObject.GetState())
+	smVStateReport.stepProcess(execCtx)
+	require.Equal(t, object.Empty, smObject.GetState())
+	require.Equal(t, uint8(1), smObject.ActiveUnorderedPendingCount)
+	require.Equal(t, uint8(1), smObject.ActiveOrderedPendingCount)
+	require.Nil(t, smObject.Descriptor())
+
+	require.NoError(t, catalog.CheckDone())
+	mc.Finish()
+}

--- a/ledger-core/v2/virtual/handlers/vstaterequest_test.go
+++ b/ledger-core/v2/virtual/handlers/vstaterequest_test.go
@@ -1,0 +1,63 @@
+// Copyright 2020 Insolar Network Ltd.
+// All rights reserved.
+// This material is licensed under the Insolar License version 1.0,
+// available at https://github.com/insolar/assured-ledger/blob/master/LICENSE.md.
+
+package handlers
+
+import (
+	"testing"
+
+	"github.com/gojuno/minimock/v3"
+	"github.com/stretchr/testify/require"
+
+	"github.com/insolar/assured-ledger/ledger-core/v2/conveyor/smachine"
+	"github.com/insolar/assured-ledger/ledger-core/v2/insolar/contract"
+	"github.com/insolar/assured-ledger/ledger-core/v2/insolar/payload"
+	"github.com/insolar/assured-ledger/ledger-core/v2/pulse"
+	"github.com/insolar/assured-ledger/ledger-core/v2/reference"
+	"github.com/insolar/assured-ledger/ledger-core/v2/testutils/gen"
+	"github.com/insolar/assured-ledger/ledger-core/v2/vanilla/longbits"
+	"github.com/insolar/assured-ledger/ledger-core/v2/virtual/object"
+	"github.com/insolar/assured-ledger/ledger-core/v2/virtual/testutils/shareddata"
+)
+
+func TestVStateRequest_ProcessObjectWithoutState(t *testing.T) {
+	var (
+		mc               = minimock.NewController(t)
+		pd               = pulse.NewFirstPulsarData(10, longbits.Bits256{})
+		catalog          = object.NewCatalogMockWrapper(mc)
+		smObjectID       = gen.UniqueIDWithPulse(pd.PulseNumber)
+		smGlobalRef      = reference.NewSelf(smObjectID)
+		smObject         = object.NewStateMachineObject(smGlobalRef)
+		sharedStateData  = smachine.NewUnboundSharedData(&smObject.SharedState)
+		smObjectAccessor = object.SharedStateAccessor{SharedDataLink: sharedStateData}
+	)
+
+	catalog.AddObject(smGlobalRef, smObjectAccessor)
+	catalog.AllowAccessMode(object.CatalogMockAccessTryGet)
+
+	smObject.SetState(object.Empty)
+	smObject.IncrementPotentialPendingCounter(contract.ConstructorIsolation())
+
+	smVStateReport := SMVStateRequest{
+		Payload: &payload.VStateRequest{
+			Callee: smGlobalRef,
+		},
+		objectCatalog: catalog.Mock(),
+	}
+
+	execCtx := smachine.NewExecutionContextMock(mc).
+		UseSharedMock.Set(shareddata.CallSharedDataAccessor).
+		JumpMock.Return(smachine.StateUpdate{})
+
+	smVStateReport.stepProcess(execCtx)
+
+	require.True(t, smVStateReport.objectStateReport.LatestDirtyState.IsZero())
+	require.Equal(t, int32(0), smVStateReport.objectStateReport.UnorderedPendingCount)
+	require.Equal(t, int32(1), smVStateReport.objectStateReport.OrderedPendingCount)
+	require.Nil(t, smVStateReport.objectStateReport.ProvidedContent.LatestDirtyState)
+
+	require.NoError(t, catalog.CheckDone())
+	mc.Finish()
+}

--- a/ledger-core/v2/virtual/integration/staterequest_test.go
+++ b/ledger-core/v2/virtual/integration/staterequest_test.go
@@ -85,6 +85,7 @@ func TestVirtual_VStateRequest_WithoutBody(t *testing.T) {
 			AsOf:             server.GetPulse().PulseNumber,
 			Callee:           objectRef,
 			LatestDirtyState: objectRef,
+			ProvidedContent:  &payload.VStateReport_ProvidedContentBody{},
 		}, data)
 	case <-time.After(10 * time.Second):
 		require.Failf(t, "", "timeout")

--- a/ledger-core/v2/virtual/object/object_migration_test.go
+++ b/ledger-core/v2/virtual/object/object_migration_test.go
@@ -26,65 +26,132 @@ import (
 	"github.com/insolar/assured-ledger/ledger-core/v2/virtual/testutils/utils"
 )
 
-func TestSMObject_MigrateFail_IfStateIsEmptyAndNoCounters(t *testing.T) {
+func TestSMObject_InitSetMigration(t *testing.T) {
 	var (
 		mc = minimock.NewController(t)
 
-		smObject        = newSMObjectWithPulseAndDescriptor()
+		smObject        = newSMObjectWithPulse()
 		sharedStateData = smachine.NewUnboundSharedData(&smObject.SharedState)
 	)
 
-	stepChecker := stepchecker.New()
-	{
-		exec := SMObject{}
-		stepChecker.AddStep(exec.stepGetState)
+	compareDefaultMigration := func(fn smachine.MigrateFunc) {
+		require.True(t, utils.CmpStateFuncs(smObject.migrate, fn))
 	}
+	initCtx := smachine.NewInitializationContextMock(mc).
+		ShareMock.Return(sharedStateData).
+		PublishMock.Expect(smObject.Reference.String(), sharedStateData).Return(true).
+		JumpMock.Return(smachine.StateUpdate{}).
+		SetDefaultMigrationMock.Set(compareDefaultMigration)
 
-	smObject.SharedState.SetState(Empty)
+	smObject.Init(initCtx)
 
-	{ // check Init set migration and Jmp to stepGetState
-		compareDefaultMigration := func(fn smachine.MigrateFunc) {
-			require.True(t, utils.CmpStateFuncs(smObject.migrate, fn))
-		}
-		initCtx := smachine.NewInitializationContextMock(mc).
-			ShareMock.Return(sharedStateData).
-			PublishMock.Expect(smObject.Reference.String(), sharedStateData).Return(true).
-			JumpMock.Set(stepChecker.CheckJumpW(t)).
-			SetDefaultMigrationMock.Set(compareDefaultMigration)
-
-		smObject.Init(initCtx)
-	}
-
-	{ // check migration will panic if state is Empty and no pending counters set
-		migrationCtx := smachine.NewMigrationContextMock(mc).
-			AffectedStepMock.Return(smachine.SlotStep{Transition: smObject.stepWaitIndefinitely})
-
-		require.Panics(t, func() { smObject.migrate(migrationCtx) })
-	}
-
-	{ // finish test
-		require.NoError(t, stepChecker.CheckDone())
-		mc.Finish()
-	}
+	mc.Finish()
 }
 
-func TestSMObject_SendVStateUnavailableAfterMigration_IfStateMissing(t *testing.T) {
+func TestSMObject_MigrationFail_IfStateIsEmptyAndNoCounters(t *testing.T) {
 	var (
 		mc = minimock.NewController(t)
 
-		smObject             = newSMObjectWithPulseAndDescriptor()
-		msgVStateUnavailable = 0
-		sharedStateData      = smachine.NewUnboundSharedData(&smObject.SharedState)
+		smObject = newSMObjectWithPulse()
+	)
+
+	smObject.SetDescriptor(descriptor.NewObject(reference.Global{}, reference.Local{}, reference.Global{}, nil, reference.Global{}))
+	smObject.SharedState.SetState(Empty)
+
+	migrationCtx := smachine.NewMigrationContextMock(mc).
+		AffectedStepMock.Return(smachine.SlotStep{Transition: smObject.stepWaitIndefinitely})
+
+	require.Panics(t, func() { smObject.migrate(migrationCtx) })
+
+	mc.Finish()
+}
+
+func TestSMObject_MigrationJmpToStepSendVStateUnavailable_IfStateMissing(t *testing.T) {
+	var (
+		mc = minimock.NewController(t)
+
+		smObject = newSMObjectWithPulse()
 	)
 
 	stepChecker := stepchecker.New()
 	{
 		exec := SMObject{}
-		stepChecker.AddStep(exec.stepGetState)
 		stepChecker.AddStep(exec.stepSendVStateUnavailable)
-		stepChecker.AddStep(exec.stepWaitIndefinitely)
 	}
 
+	smObject.SetDescriptor(descriptor.NewObject(reference.Global{}, reference.Local{}, reference.Global{}, nil, reference.Global{}))
+	smObject.SharedState.SetState(Missing)
+	smObject.IncrementPotentialPendingCounter(contract.MethodIsolation{
+		Interference: contract.CallIntolerable,
+		State:        contract.CallValidated,
+	})
+
+	migrationCtx := smachine.NewMigrationContextMock(mc).
+		AffectedStepMock.Return(smachine.SlotStep{Transition: smObject.stepWaitIndefinitely}).
+		JumpMock.Set(stepChecker.CheckJumpW(t))
+
+	smObject.migrate(migrationCtx)
+
+	require.NoError(t, stepChecker.CheckDone())
+	mc.Finish()
+}
+
+func TestSMObject_MigrationSendNothing_IfStateUnknown(t *testing.T) {
+	var (
+		mc = minimock.NewController(t)
+
+		smObject = newSMObjectWithPulse()
+	)
+	smObject.SetState(Unknown)
+
+	migrationCtx := smachine.NewMigrationContextMock(mc).
+		AffectedStepMock.Return(smachine.SlotStep{Transition: smObject.stepWaitIndefinitely}).
+		LogMock.Return(smachine.Logger{}).
+		StayMock.Return(smachine.StateUpdate{})
+
+	smObject.migrate(migrationCtx)
+
+	mc.Finish()
+}
+
+func TestSMObject_MigrationJmpToStepSendVStateReport_IfStateEmptyAndCountersSet(t *testing.T) {
+	var (
+		mc = minimock.NewController(t)
+
+		smObject = newSMObjectWithPulse()
+	)
+
+	stepChecker := stepchecker.New()
+	{
+		exec := SMObject{}
+		stepChecker.AddStep(exec.stepSendVStateReport)
+	}
+
+	smObject.SharedState.SetState(Empty)
+	smObject.IncrementPotentialPendingCounter(contract.MethodIsolation{
+		Interference: contract.CallIntolerable,
+		State:        contract.CallValidated,
+	})
+
+	migrationCtx := smachine.NewMigrationContextMock(mc).
+		AffectedStepMock.Return(smachine.SlotStep{Transition: smObject.stepWaitIndefinitely}).
+		JumpMock.Set(stepChecker.CheckJumpW(t))
+
+	smObject.migrate(migrationCtx)
+
+	require.NoError(t, stepChecker.CheckDone())
+	mc.Finish()
+}
+
+func TestSMObject_SendVStateUnavailable(t *testing.T) {
+	var (
+		mc = minimock.NewController(t)
+
+		smObject             = newSMObjectWithPulse()
+		msgVStateUnavailable = 0
+	)
+
+	smObject.SetDescriptor(descriptor.NewObject(reference.Global{}, reference.Local{}, reference.Global{}, nil, reference.Global{}))
 	smObject.SharedState.SetState(Missing)
 	smObject.IncrementPotentialPendingCounter(contract.MethodIsolation{
 		Interference: contract.CallIntolerable,
@@ -102,67 +169,33 @@ func TestSMObject_SendVStateUnavailableAfterMigration_IfStateMissing(t *testing.
 
 	smObject.messageSender = messageSender.Mock()
 
-	{ // check migration is set
-		compareDefaultMigration := func(fn smachine.MigrateFunc) {
-			require.True(t, utils.CmpStateFuncs(smObject.migrate, fn))
-		}
-		initCtx := smachine.NewInitializationContextMock(mc).
-			ShareMock.Return(sharedStateData).
-			PublishMock.Expect(smObject.Reference.String(), sharedStateData).Return(true).
-			SetDefaultMigrationMock.Set(compareDefaultMigration).
-			JumpMock.Set(stepChecker.CheckJumpW(t))
+	execCtx := smachine.NewExecutionContextMock(mc).
+		JumpMock.Return(smachine.StateUpdate{})
 
-		smObject.Init(initCtx)
-	}
+	smObject.stepSendVStateUnavailable(execCtx)
+	require.Equal(t, 1, msgVStateUnavailable)
 
-	{ // check migration is successful
-		migrationCtx := smachine.NewMigrationContextMock(mc).
-			AffectedStepMock.Return(smachine.SlotStep{Transition: smObject.stepWaitIndefinitely}).
-			JumpMock.Set(stepChecker.CheckJumpW(t))
-
-		smObject.migrate(migrationCtx)
-	}
-
-	{ // check execution of step after migration
-		execCtx := smachine.NewExecutionContextMock(mc).
-			JumpMock.Set(stepChecker.CheckJumpW(t))
-
-		smObject.stepSendVStateUnavailable(execCtx)
-		require.Equal(t, 1, msgVStateUnavailable)
-	}
-
-	{ // finish test
-		require.NoError(t, stepChecker.CheckDone())
-		mc.Finish()
-	}
+	mc.Finish()
 }
 
-func TestSMObject_SendVStateReportAfterMigration_IfStateEmptyAndCountersSet(t *testing.T) {
+func TestSMObject_SendVStateReport_IfDescriptorSet(t *testing.T) {
 	var (
 		mc = minimock.NewController(t)
 
-		smObject             = newSMObjectWithPulseAndDescriptor()
+		smObject             = newSMObjectWithPulse()
 		msgVStateReportCount = 0
-		sharedStateData      = smachine.NewUnboundSharedData(&smObject.SharedState)
 	)
 
-	stepChecker := stepchecker.New()
-	{
-		exec := SMObject{}
-		stepChecker.AddStep(exec.stepGetState)
-		stepChecker.AddStep(exec.stepSendVStateReport)
-		stepChecker.AddStep(exec.stepWaitIndefinitely)
-	}
+	smObject.SetDescriptor(descriptor.NewObject(reference.Global{}, reference.Local{}, reference.Global{}, nil, reference.Global{}))
+	smObject.SharedState.SetState(HasState)
 
-	smObject.SharedState.SetState(Empty)
-	smObject.IncrementPotentialPendingCounter(contract.MethodIsolation{
-		Interference: contract.CallIntolerable,
-		State:        contract.CallValidated,
-	})
 	messageService := messageSenderWrapper.NewServiceMockWrapper(mc)
 	checkMessageFn := func(msg payload.Marshaler) {
-		_, ok := msg.(*payload.VStateReport)
+		stateReport, ok := msg.(*payload.VStateReport)
 		require.True(t, ok)
+		require.True(t, ok)
+		require.NotNil(t, stateReport.ProvidedContent)
+		require.NotNil(t, stateReport.ProvidedContent.LatestDirtyState)
 		msgVStateReportCount++
 	}
 	messageService.SendRole.SetCheckMessage(checkMessageFn)
@@ -170,90 +203,57 @@ func TestSMObject_SendVStateReportAfterMigration_IfStateEmptyAndCountersSet(t *t
 
 	smObject.messageSender = messageSender.Mock()
 
-	{ // check migration is set
-		compareDefaultMigration := func(fn smachine.MigrateFunc) {
-			require.True(t, utils.CmpStateFuncs(smObject.migrate, fn))
-		}
-		initCtx := smachine.NewInitializationContextMock(mc).
-			ShareMock.Return(sharedStateData).
-			PublishMock.Expect(smObject.Reference.String(), sharedStateData).Return(true).
-			SetDefaultMigrationMock.Set(compareDefaultMigration).
-			JumpMock.Set(stepChecker.CheckJumpW(t))
+	execCtx := smachine.NewExecutionContextMock(mc).
+		JumpMock.Return(smachine.StateUpdate{})
 
-		smObject.Init(initCtx)
-	}
+	smObject.stepSendVStateReport(execCtx)
+	require.Equal(t, 1, msgVStateReportCount)
 
-	{ // check migration is successful
-		migrationCtx := smachine.NewMigrationContextMock(mc).
-			AffectedStepMock.Return(smachine.SlotStep{Transition: smObject.stepWaitIndefinitely}).
-			JumpMock.Set(stepChecker.CheckJumpW(t))
-
-		smObject.migrate(migrationCtx)
-	}
-
-	{ // check execution of step after migration
-		execCtx := smachine.NewExecutionContextMock(mc).
-			JumpMock.Set(stepChecker.CheckJumpW(t))
-
-		smObject.stepSendVStateReport(execCtx)
-		require.Equal(t, 1, msgVStateReportCount)
-	}
-
-	{ // finish test
-		require.NoError(t, stepChecker.CheckDone())
-		mc.Finish()
-	}
+	mc.Finish()
 }
 
-func TestSMObject_SendNothingAfterMigration_IfStateUnknown(t *testing.T) {
+func TestSMObject_SendVStateReport_IfDescriptorNotSetAndStateEmpty(t *testing.T) {
 	var (
 		mc = minimock.NewController(t)
 
-		smObject        = newSMObjectWithPulseAndDescriptor()
-		sharedStateData = smachine.NewUnboundSharedData(&smObject.SharedState)
+		smObject             = newSMObjectWithPulse()
+		msgVStateReportCount = 0
 	)
+	smObject.SetState(Empty)
 
-	stepChecker := stepchecker.New()
-	{
-		exec := SMObject{}
-		stepChecker.AddStep(exec.stepGetState)
+	messageService := messageSenderWrapper.NewServiceMockWrapper(mc)
+	checkMessageFn := func(msg payload.Marshaler) {
+		stateReport, ok := msg.(*payload.VStateReport)
+		require.True(t, ok)
+		require.True(t, stateReport.LatestDirtyState.IsZero())
+		require.NotNil(t, stateReport.ProvidedContent)
+		require.Nil(t, stateReport.ProvidedContent.LatestDirtyState)
+		msgVStateReportCount++
 	}
+	messageService.SendRole.SetCheckMessage(checkMessageFn)
+	messageSender := messageService.NewAdapterMock().SetDefaultPrepareAsyncCall(inslogger.TestContext(t))
 
-	{ // check migration is set
-		compareDefaultMigration := func(fn smachine.MigrateFunc) {
-			require.True(t, utils.CmpStateFuncs(smObject.migrate, fn))
-		}
-		initCtx := smachine.NewInitializationContextMock(mc).
-			ShareMock.Return(sharedStateData).
-			PublishMock.Expect(smObject.Reference.String(), sharedStateData).Return(true).
-			SetDefaultMigrationMock.Set(compareDefaultMigration).
-			JumpMock.Set(stepChecker.CheckJumpW(t))
+	smObject.messageSender = messageSender.Mock()
 
-		smObject.Init(initCtx)
-	}
+	require.Equal(t, nil, smObject.descriptor)
+	execCtx := smachine.NewExecutionContextMock(mc).
+		JumpMock.Return(smachine.StateUpdate{})
 
-	{ // check migration is successful
-		migrationCtx := smachine.NewMigrationContextMock(mc).
-			AffectedStepMock.Return(smachine.SlotStep{Transition: smObject.stepWaitIndefinitely}).
-			LogMock.Return(smachine.Logger{}).
-			StayMock.Return(smachine.StateUpdate{})
+	smObject.stepSendVStateReport(execCtx)
+	require.Equal(t, 1, msgVStateReportCount)
 
-		smObject.migrate(migrationCtx)
-	}
-
-	{ // finish test
-		require.NoError(t, stepChecker.CheckDone())
-		mc.Finish()
-	}
+	mc.Finish()
 }
 
 func TestSMObject_DoNotSendVStateReportTwiceButIncMigrationCounter(t *testing.T) {
 	var (
 		mc = minimock.NewController(t)
 
-		smObject             = newSMObjectWithPulseAndDescriptor()
+		smObject             = newSMObjectWithPulse()
 		msgVStateReportCount = 0
 	)
+
+	smObject.SetDescriptor(descriptor.NewObject(reference.Global{}, reference.Local{}, reference.Global{}, nil, reference.Global{}))
 	smObject.SetState(HasState)
 
 	messageService := messageSenderWrapper.NewServiceMockWrapper(mc)
@@ -267,7 +267,7 @@ func TestSMObject_DoNotSendVStateReportTwiceButIncMigrationCounter(t *testing.T)
 
 	smObject.messageSender = messageSender.Mock()
 
-	{ // first call send VStateReport and increment stateSentCount
+	{ // first call send VStateReport
 		require.Equal(t, stateWasNotSend, smObject.migrateState)
 		execCtx := smachine.NewExecutionContextMock(mc).
 			JumpMock.Return(smachine.StateUpdate{})
@@ -277,7 +277,7 @@ func TestSMObject_DoNotSendVStateReportTwiceButIncMigrationCounter(t *testing.T)
 		require.Equal(t, stateSent, smObject.migrateState)
 	}
 
-	{ // next calls do not send VStateReport but increment stateSentCount
+	{ // next calls do not send VStateReport
 		execCtx := smachine.NewExecutionContextMock(mc).
 			JumpMock.Return(smachine.StateUpdate{})
 
@@ -295,8 +295,9 @@ func TestSMObject_StopIfVStateReportWasSendAndNoPendingExecution(t *testing.T) {
 	var (
 		mc = minimock.NewController(t)
 
-		smObject = newSMObjectWithPulseAndDescriptor()
+		smObject = newSMObjectWithPulse()
 	)
+	smObject.SetDescriptor(descriptor.NewObject(reference.Global{}, reference.Local{}, reference.Global{}, nil, reference.Global{}))
 
 	{ // stepWaitIndefinitely continue if not migrated and no pending exist
 		smObject.migrateState = stateWasNotSend
@@ -366,7 +367,7 @@ func TestSMObject_StopIfVStateReportWasSendAndNoPendingExecution(t *testing.T) {
 	}
 }
 
-func newSMObjectWithPulseAndDescriptor() *SMObject {
+func newSMObjectWithPulse() *SMObject {
 	var (
 		pd          = pulse.NewFirstPulsarData(10, longbits.Bits256{})
 		pulseSlot   = conveyor.NewPresentPulseSlot(nil, pd.AsRange())
@@ -376,7 +377,6 @@ func newSMObjectWithPulseAndDescriptor() *SMObject {
 	)
 
 	smObject.pulseSlot = &pulseSlot
-	smObject.SetDescriptor(descriptor.NewObject(reference.Global{}, reference.Local{}, reference.Global{}, nil, reference.Global{}))
 
 	return smObject
 }

--- a/ledger-core/v2/virtual/testutils/shareddata/utils.go
+++ b/ledger-core/v2/virtual/testutils/shareddata/utils.go
@@ -3,7 +3,7 @@
 // This material is licensed under the Insolar License version 1.0,
 // available at https://github.com/insolar/assured-ledger/blob/master/LICENSE.md.
 
-package execute
+package shareddata
 
 import (
 	"reflect"
@@ -12,12 +12,12 @@ import (
 	"github.com/insolar/assured-ledger/ledger-core/v2/conveyor/smachine"
 )
 
-type SharedDataAccessorWrapper struct {
+type AccessorWrapper struct {
 	a *smachine.SharedDataAccessor
 }
 
-func NewSharedDataAccessorWrapper(a *smachine.SharedDataAccessor) SharedDataAccessorWrapper {
-	return SharedDataAccessorWrapper{a: a}
+func NewSharedDataAccessorWrapper(a *smachine.SharedDataAccessor) AccessorWrapper {
+	return AccessorWrapper{a: a}
 }
 
 func getFieldAsInterface(val reflect.Value, fieldPos int) interface{} {
@@ -25,16 +25,16 @@ func getFieldAsInterface(val reflect.Value, fieldPos int) interface{} {
 	return reflect.NewAt(field.Type(), unsafe.Pointer(field.UnsafeAddr())).Elem().Interface()
 }
 
-func (w SharedDataAccessorWrapper) getLink() *smachine.SharedDataLink {
+func (w AccessorWrapper) getLink() *smachine.SharedDataLink {
 	return getFieldAsInterface(reflect.ValueOf(w.a).Elem(), 0).(*smachine.SharedDataLink)
 }
 
-func (w SharedDataAccessorWrapper) getAccessFn() smachine.SharedDataFunc {
+func (w AccessorWrapper) getAccessFn() smachine.SharedDataFunc {
 	reflectValue := reflect.ValueOf(w.a).Elem()
 	return getFieldAsInterface(reflectValue, 1).(smachine.SharedDataFunc)
 }
 
-func (w SharedDataAccessorWrapper) getAccessFnData() interface{} {
+func (w AccessorWrapper) getAccessFnData() interface{} {
 	reflectValue := reflect.ValueOf(w.getLink()).Elem()
 	return getFieldAsInterface(reflectValue, 1)
 }


### PR DESCRIPTION
**- What I did**
* Fix sending VStateReport without Descriptor in SMObject
* Fix processing VStateReport without LatestDirtyState

**- How I did it**
SMObject send VStateReport with nil in LatestDirtyState. VStateReport handler create SMObject with state Empty

**- How to verify it**
Run test 

**- Description for the changelog**
