### PR TITLE
PLAT-311: process VStateReport fields for earliest pulses

### DIFF
--- a/ledger-core/v2/virtual/handlers/vstatereport.go
+++ b/ledger-core/v2/virtual/handlers/vstatereport.go
@@ -87,6 +87,9 @@ func (s *SMVStateReport) stepProcess(ctx smachine.ExecutionContext) smachine.Sta
 		state.ActiveUnorderedPendingCount = uint8(s.Payload.UnorderedPendingCount)
 		state.ActiveOrderedPendingCount = uint8(s.Payload.OrderedPendingCount)
 
+		state.OrderedPendingEarliestPulse = s.Payload.OrderedPendingEarliestPulse
+		state.UnorderedPendingEarliestPulse = s.Payload.UnorderedPendingEarliestPulse
+
 		if objectDescriptor != nil {
 			state.SetDescriptor(objectDescriptor)
 			state.SetState(object.HasState)

--- a/ledger-core/v2/virtual/object/object.go
+++ b/ledger-core/v2/virtual/object/object.go
@@ -15,6 +15,7 @@ import (
 	"github.com/insolar/assured-ledger/ledger-core/v2/insolar/contract"
 	"github.com/insolar/assured-ledger/ledger-core/v2/insolar/node"
 	"github.com/insolar/assured-ledger/ledger-core/v2/insolar/payload"
+	"github.com/insolar/assured-ledger/ledger-core/v2/pulse"
 	"github.com/insolar/assured-ledger/ledger-core/v2/reference"
 	"github.com/insolar/assured-ledger/ledger-core/v2/vanilla/throw"
 
@@ -51,10 +52,16 @@ type Info struct {
 	KnownRequests map[reference.Global]struct{}
 	PendingTable  PendingTable
 
-	ActiveUnorderedPendingCount    uint8
-	ActiveOrderedPendingCount      uint8
+	// Active means pendings on other executors
+	ActiveUnorderedPendingCount uint8
+	ActiveOrderedPendingCount   uint8
+
+	// Potential means pendings on this executor
 	PotentialUnorderedPendingCount uint8
 	PotentialOrderedPendingCount   uint8
+
+	UnorderedPendingEarliestPulse pulse.Number
+	OrderedPendingEarliestPulse   pulse.Number
 
 	objectState State
 }


### PR DESCRIPTION
**- What I did**
VStateReport handler should store EarliestRequestPulse in state object

Fillage of EarliestRequestPulse in different PR
