### PR TITLE
PLAT-352: run functest many times on `master` with reduced pulse time

### DIFF
--- a/.github/workflows/linux-checks.yaml
+++ b/.github/workflows/linux-checks.yaml
@@ -54,6 +54,10 @@ jobs:
         if: always()
         run: make test_func_race
         working-directory: ${{env.GOPATH}}/src/github.com/insolar/assured-ledger/ledger-core/v2
+      - name: Run functional tests many times on `master` with reduced pulse time
+        if: ${{ github.event_name == 'push' }}
+        run: make test_func_slow
+        working-directory: ${{env.GOPATH}}/src/github.com/insolar/assured-ledger/ledger-core/v2
       - name: Install testrail-cli
         if: ${{ github.event_name == 'push' }}
         run: |

--- a/ledger-core/v2/Makefile.testing
+++ b/ledger-core/v2/Makefile.testing
@@ -25,13 +25,10 @@ test_func: ## run functest FUNCTEST_COUNT times
 	PULSAR_PULSETIME=$(PULSAR_PULSETIME) \
 	CGO_ENABLED=1 $(GOTEST) -test.v $(TEST_ARGS) -tags "functest" ./application/functest -count=$(FUNCTEST_COUNT)
 
-.PHONY: test_func_very_slow
-test_func_very_slow: ## run functest 100 times with enabled pulse 3 sec
-	FUNCTEST_COUNT=100 PULSAR_ONESHOT=FALSE PULSAR_PULSETIME=3000 TEST_ARGS='-timeout 1200s -failfast' make test_func
-
 .PHONY: test_func_slow
 test_func_slow: # Run functests as long as practical to catch unexpected behavior during pulse change
-	FUNCTEST_COUNT=1000 TEST_ARGS='-timeout 1200s -failfast' make test_func
+	pgrep insolard | xargs kill -9 # dirty hack to terminate all insolard processes
+	FUNCTEST_COUNT=100 PULSAR_ONESHOT=FALSE PULSAR_PULSETIME=5000 TEST_ARGS='-timeout 1200s -failfast' make test_func
 
 .PNONY: test_func_race
 test_func_race: ## run functest 10 times with -race flag

--- a/ledger-core/v2/Makefile.testing
+++ b/ledger-core/v2/Makefile.testing
@@ -25,9 +25,13 @@ test_func: ## run functest FUNCTEST_COUNT times
 	PULSAR_PULSETIME=$(PULSAR_PULSETIME) \
 	CGO_ENABLED=1 $(GOTEST) -test.v $(TEST_ARGS) -tags "functest" ./application/functest -count=$(FUNCTEST_COUNT)
 
-.PHONY: test_func_slow
-test_func_slow: ## run functest 100 times with enabled pulse 3 sec
+.PHONY: test_func_very_slow
+test_func_very_slow: ## run functest 100 times with enabled pulse 3 sec
 	FUNCTEST_COUNT=100 PULSAR_ONESHOT=FALSE PULSAR_PULSETIME=3000 TEST_ARGS='-timeout 1200s -failfast' make test_func
+
+.PHONY: test_func_slow
+test_func_slow: # Run functests as long as practical to catch unexpected behavior during pulse change
+	FUNCTEST_COUNT=1000 TEST_ARGS='-timeout 1200s -failfast' make test_func
 
 .PNONY: test_func_race
 test_func_race: ## run functest 10 times with -race flag


### PR DESCRIPTION
The proposed patch already catches some issues. I believe this is good enough for now.