### PR TITLE
NOISSUE: master-checks.yaml - ignore `make test_func_slow` until ~28.06.2020

### DIFF
--- a/.github/workflows/master-checks.yaml
+++ b/.github/workflows/master-checks.yaml
@@ -66,7 +66,7 @@ jobs:
         working-directory: ${{env.GOPATH}}/src/github.com/insolar/assured-ledger/ledger-core/v2
       - name: Run functional tests many times on `master` with reduced pulse time
         if: always()
-        run: make test_func_slow
+        run: make test_func_slow || ./scripts/func-slow-should-be-ignored.py
         working-directory: ${{env.GOPATH}}/src/github.com/insolar/assured-ledger/ledger-core/v2
       - name: Install testrail-cli
         if: always()

--- a/ledger-core/v2/scripts/func-slow-should-be-ignored.py
+++ b/ledger-core/v2/scripts/func-slow-should-be-ignored.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python3
+
+import time
+import sys
+
+# `make test_func_slow` errors should be ignored until ~28.06.2020
+# this is an estimated date when Release 0 Milestone 3 will be ready
+if time.time() > 1593332989:
+	sys.exit(1) # false, don't ignore
+
+# true, tests should be ignored
+sys.exit(0)

--- a/ledger-core/v2/scripts/func-slow-should-be-ignored.py
+++ b/ledger-core/v2/scripts/func-slow-should-be-ignored.py
@@ -1,11 +1,14 @@
 #!/usr/bin/env python3
 
 import time
+import datetime
 import sys
 
 # `make test_func_slow` errors should be ignored until ~28.06.2020
 # this is an estimated date when Release 0 Milestone 3 will be ready
-if time.time() > 1593332989:
+m3date = "28.06.2020"
+tup = datetime.datetime.strptime(m3date, "%d.%m.%Y").timetuple()
+if time.time() > time.mktime(tup):
 	sys.exit(1) # false, don't ignore
 
 # true, tests should be ignored


### PR DESCRIPTION
This patch just automates what we currently have to do manually.