### PR TITLE
PLAT-420: Implement runner adapter mock

### DIFF
--- a/ledger-core/go.mod
+++ b/ledger-core/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/fsnotify/fsnotify v1.4.7
 	github.com/getkin/kin-openapi v0.2.1-0.20191211203508-0d9caf80ada6
 	github.com/gogo/protobuf v1.3.1
+	github.com/gojuno/minimock v1.9.2
 	github.com/gojuno/minimock/v3 v3.0.6
 	github.com/golang/protobuf v1.3.2
 	github.com/google/gofuzz v1.0.0

--- a/ledger-core/runner/adapter.go
+++ b/ledger-core/runner/adapter.go
@@ -26,49 +26,66 @@ const (
 	Abort
 )
 
-type RunState struct {
+type RunState interface {
+	GetResult() *executionupdate.ContractExecutionStateUpdate
+	GetID() call.ID
+}
+
+type runState struct {
 	state *executionEventSink
 	mode  RunMode
 }
 
-func (r *RunState) GetResult() *executionupdate.ContractExecutionStateUpdate {
+func (r runState) GetResult() *executionupdate.ContractExecutionStateUpdate {
 	return r.state.GetResult()
 }
 
-func (r RunState) GetID() call.ID {
+func (r runState) GetID() call.ID {
 	return r.state.id
 }
 
 type runnerServiceInterceptor struct {
 	svc  *DefaultService
-	last *RunState
+	last *runState
 }
 
-var _ Service = &runnerServiceInterceptor{}
+var _ UnmanagedService = &runnerServiceInterceptor{}
 
-func (p *runnerServiceInterceptor) ExecutionStart(execution execution.Context) *RunState {
+func (p *runnerServiceInterceptor) ExecutionStart(execution execution.Context) RunState {
 	if p.last != nil {
 		panic(throw.IllegalState())
 	}
-	p.last = &RunState{p.svc.runPrepare(execution), Start}
+	p.last = &runState{p.svc.runPrepare(execution), Start}
 	return p.last
 }
 
-func (p *runnerServiceInterceptor) ExecutionContinue(run *RunState, outgoingResult []byte) {
+func (p *runnerServiceInterceptor) ExecutionContinue(run RunState, outgoingResult []byte) {
 	if p.last != nil {
 		panic(throw.IllegalState())
 	}
-	p.last = run
-	run.state.input <- outgoingResult
-	run.mode = Continue
+	var ok bool
+	p.last, ok = run.(*runState)
+	if !ok {
+		panic(throw.IllegalValue())
+	}
+	p.last.state.input <- outgoingResult
+	p.last.mode = Continue
 }
 
-func (p *runnerServiceInterceptor) ExecutionAbort(run *RunState) {
+func (p *runnerServiceInterceptor) ExecutionAbort(run RunState) {
 	if p.last != nil {
 		panic(throw.IllegalState())
 	}
-	p.last = run
-	run.mode = Abort
+	var ok bool
+	p.last, ok = run.(*runState)
+	if !ok {
+		panic(throw.IllegalValue())
+	}
+	p.last.mode = Abort
+}
+
+func (p *runnerServiceInterceptor) ExecutionClassify(_ execution.Context) (contract.MethodIsolation, error) {
+	panic(throw.Impossible())
 }
 
 type awaitedRun struct {
@@ -78,24 +95,31 @@ type awaitedRun struct {
 
 // ================================= Adapter =================================
 
-type ServiceAdapter struct {
+type serviceAdapter struct {
 	svc          *DefaultService
 	runExec      smachine.ExecutionAdapter
 	parallelExec smachine.ExecutionAdapter
 }
 
-func (a *ServiceAdapter) PrepareExecutionStart(ctx smachine.ExecutionContext, execution execution.Context, fn func(*RunState)) smachine.AsyncCallRequester {
+type ServiceAdapter interface {
+	PrepareExecutionStart(ctx smachine.ExecutionContext, execution execution.Context, fn func(RunState)) smachine.AsyncCallRequester
+	PrepareExecutionContinue(ctx smachine.ExecutionContext, state RunState, outgoingResult []byte, fn func()) smachine.AsyncCallRequester
+	PrepareExecutionAbort(ctx smachine.ExecutionContext, state RunState, fn func()) smachine.AsyncCallRequester
+	PrepareExecutionClassify(ctx smachine.ExecutionContext, execution execution.Context, fn func(contract.MethodIsolation, error)) smachine.AsyncCallRequester
+}
+
+func (a *serviceAdapter) PrepareExecutionStart(ctx smachine.ExecutionContext, execution execution.Context, fn func(RunState)) smachine.AsyncCallRequester {
 	if fn == nil {
 		panic(throw.IllegalValue())
 	}
 
 	return a.runExec.PrepareAsync(ctx, func(_ context.Context, arg interface{}) smachine.AsyncResultFunc {
-		state := arg.(Service).ExecutionStart(execution)
+		state := arg.(UnmanagedService).ExecutionStart(execution)
 		return func(ctx smachine.AsyncResultContext) { fn(state) }
 	})
 }
 
-func (a *ServiceAdapter) PrepareExecutionContinue(ctx smachine.ExecutionContext, state *RunState, outgoingResult []byte, fn func()) smachine.AsyncCallRequester {
+func (a *serviceAdapter) PrepareExecutionContinue(ctx smachine.ExecutionContext, state RunState, outgoingResult []byte, fn func()) smachine.AsyncCallRequester {
 	if state == nil {
 		panic(throw.IllegalValue())
 	}
@@ -104,7 +128,7 @@ func (a *ServiceAdapter) PrepareExecutionContinue(ctx smachine.ExecutionContext,
 	}
 
 	return a.runExec.PrepareAsync(ctx, func(_ context.Context, arg interface{}) smachine.AsyncResultFunc {
-		arg.(Service).ExecutionContinue(state, outgoingResult)
+		arg.(UnmanagedService).ExecutionContinue(state, outgoingResult)
 		return func(ctx smachine.AsyncResultContext) {
 			if fn != nil {
 				fn()
@@ -113,13 +137,13 @@ func (a *ServiceAdapter) PrepareExecutionContinue(ctx smachine.ExecutionContext,
 	})
 }
 
-func (a *ServiceAdapter) PrepareExecutionAbort(ctx smachine.ExecutionContext, state *RunState, fn func()) smachine.AsyncCallRequester {
+func (a *serviceAdapter) PrepareExecutionAbort(ctx smachine.ExecutionContext, state RunState, fn func()) smachine.AsyncCallRequester {
 	if state == nil {
 		panic(throw.IllegalValue())
 	}
 
 	return a.runExec.PrepareAsync(ctx, func(_ context.Context, arg interface{}) smachine.AsyncResultFunc {
-		arg.(Service).ExecutionAbort(state)
+		arg.(UnmanagedService).ExecutionAbort(state)
 		return func(ctx smachine.AsyncResultContext) {
 			if fn != nil {
 				fn()
@@ -128,7 +152,7 @@ func (a *ServiceAdapter) PrepareExecutionAbort(ctx smachine.ExecutionContext, st
 	})
 }
 
-func (a *ServiceAdapter) PrepareExecutionClassify(ctx smachine.ExecutionContext, execution execution.Context, fn func(contract.MethodIsolation, error)) smachine.AsyncCallRequester {
+func (a *serviceAdapter) PrepareExecutionClassify(ctx smachine.ExecutionContext, execution execution.Context, fn func(contract.MethodIsolation, error)) smachine.AsyncCallRequester {
 	if fn == nil {
 		panic(throw.IllegalValue())
 	}
@@ -141,7 +165,7 @@ func (a *ServiceAdapter) PrepareExecutionClassify(ctx smachine.ExecutionContext,
 	})
 }
 
-func CreateRunnerService(ctx context.Context, svc *DefaultService) *ServiceAdapter {
+func createRunnerAdapter(ctx context.Context, svc *DefaultService) *serviceAdapter {
 	parallelReaders := 16
 
 	runAdapterExecutor, runChannel := smachine.NewCallChannelExecutor(ctx, -1, false, parallelReaders)
@@ -150,7 +174,7 @@ func CreateRunnerService(ctx context.Context, svc *DefaultService) *ServiceAdapt
 	parallelAdapterExecutor, parallelChannel := smachine.NewCallChannelExecutor(ctx, -1, false, parallelReaders)
 	smachine.StartChannelWorkerParallelCalls(ctx, 0, parallelChannel, nil)
 
-	return &ServiceAdapter{
+	return &serviceAdapter{
 		svc:          svc,
 		runExec:      smachine.NewExecutionAdapter("RunnerServiceAdapter", runAdapterExecutor),
 		parallelExec: smachine.NewExecutionAdapter("RunnerServiceAdapterParallel", parallelAdapterExecutor),

--- a/ledger-core/runner/runner.go
+++ b/ledger-core/runner/runner.go
@@ -24,14 +24,14 @@ import (
 	"github.com/insolar/assured-ledger/ledger-core/virtual/descriptor"
 )
 
-type Service interface {
-	ExecutionStart(execution execution.Context) *RunState
-	ExecutionContinue(run *RunState, outgoingResult []byte)
-	ExecutionAbort(run *RunState)
+type UnmanagedService interface {
+	ExecutionStart(execution execution.Context) RunState
+	ExecutionContinue(run RunState, outgoingResult []byte)
+	ExecutionAbort(run RunState)
 }
 
-type UnmanagedService interface {
-	ExecutionClassify(execution execution.Context) (contract.MethodIsolation, error)
+type Service interface {
+	CreateAdapter(ctx context.Context) ServiceAdapter
 }
 
 type DefaultService struct {
@@ -352,4 +352,8 @@ func (r *DefaultService) Init() error {
 	r.Cache.RegisterCallback(exec.GetDescriptor)
 
 	return nil
+}
+
+func (r *DefaultService) CreateAdapter(ctx context.Context) ServiceAdapter {
+	return createRunnerAdapter(ctx, r)
 }

--- a/ledger-core/testutils/runner/adapter/adapter.go
+++ b/ledger-core/testutils/runner/adapter/adapter.go
@@ -1,0 +1,95 @@
+// Copyright 2020 Insolar Network Ltd.
+// All rights reserved.
+// This material is licensed under the Insolar License version 1.0,
+// available at https://github.com/insolar/assured-ledger/blob/master/LICENSE.md.
+
+package adapter
+
+import (
+	"context"
+
+	"github.com/insolar/assured-ledger/ledger-core/conveyor/smachine"
+	"github.com/insolar/assured-ledger/ledger-core/insolar/contract"
+	"github.com/insolar/assured-ledger/ledger-core/runner"
+	"github.com/insolar/assured-ledger/ledger-core/runner/execution"
+	"github.com/insolar/assured-ledger/ledger-core/vanilla/throw"
+)
+
+type Service interface {
+	ExecutionStart(execution execution.Context) runner.RunState
+	ExecutionContinue(run runner.RunState, outgoingResult []byte)
+	ExecutionAbort(run runner.RunState)
+	ExecutionClassify(execution execution.Context) (contract.MethodIsolation, error)
+}
+
+func (a *Imposter) PrepareExecutionStart(ctx smachine.ExecutionContext, execution execution.Context, fn func(runner.RunState)) smachine.AsyncCallRequester {
+	if fn == nil {
+		panic(throw.IllegalValue())
+	}
+
+	return a.exec.PrepareAsync(ctx, func(_ context.Context, arg interface{}) smachine.AsyncResultFunc {
+		state := a.mockedService.ExecutionStart(execution)
+		return func(ctx smachine.AsyncResultContext) { fn(state) }
+	})
+}
+
+func (a *Imposter) PrepareExecutionContinue(ctx smachine.ExecutionContext, state runner.RunState, outgoingResult []byte, fn func()) smachine.AsyncCallRequester {
+	if state == nil {
+		panic(throw.IllegalValue())
+	}
+	if outgoingResult == nil {
+		panic(throw.IllegalValue())
+	}
+
+	return a.exec.PrepareAsync(ctx, func(_ context.Context, arg interface{}) smachine.AsyncResultFunc {
+		a.mockedService.ExecutionContinue(state, outgoingResult)
+		return func(ctx smachine.AsyncResultContext) {
+			if fn != nil {
+				fn()
+			}
+		}
+	})
+}
+
+func (a *Imposter) PrepareExecutionAbort(ctx smachine.ExecutionContext, state runner.RunState, fn func()) smachine.AsyncCallRequester {
+	if state == nil {
+		panic(throw.IllegalValue())
+	}
+
+	return a.exec.PrepareAsync(ctx, func(_ context.Context, arg interface{}) smachine.AsyncResultFunc {
+		a.mockedService.ExecutionAbort(state)
+		return func(ctx smachine.AsyncResultContext) {
+			if fn != nil {
+				fn()
+			}
+		}
+	})
+}
+
+func (a *Imposter) PrepareExecutionClassify(ctx smachine.ExecutionContext, execution execution.Context, fn func(contract.MethodIsolation, error)) smachine.AsyncCallRequester {
+	if fn == nil {
+		panic(throw.IllegalValue())
+	}
+
+	return a.exec.PrepareAsync(ctx, func(_ context.Context, arg interface{}) smachine.AsyncResultFunc {
+		classification, err := a.mockedService.ExecutionClassify(execution)
+		return func(ctx smachine.AsyncResultContext) {
+			fn(classification, err)
+		}
+	})
+}
+
+type Imposter struct {
+	exec          smachine.ExecutionAdapter
+	mockedService Service
+}
+
+func NewImposter(ctx context.Context, svc Service, parallelReaders int) *Imposter {
+	parallelAdapterExecutor, parallelChannel := smachine.NewCallChannelExecutor(ctx, -1, false, parallelReaders)
+	smachine.StartChannelWorkerParallelCalls(ctx, 0, parallelChannel, nil)
+
+	return &Imposter{
+		exec:          smachine.NewExecutionAdapter("RunnerServiceAdapterParallel", parallelAdapterExecutor),
+		mockedService: svc,
+	}
+}

--- a/ledger-core/testutils/runner/logicless/execution.go
+++ b/ledger-core/testutils/runner/logicless/execution.go
@@ -1,0 +1,122 @@
+// Copyright 2020 Insolar Network Ltd.
+// All rights reserved.
+// This material is licensed under the Insolar License version 1.0,
+// available at https://github.com/insolar/assured-ledger/blob/master/LICENSE.md.
+
+package logicless
+
+import (
+	"github.com/insolar/assured-ledger/ledger-core/runner/execution"
+	"github.com/insolar/assured-ledger/ledger-core/runner/executionupdate"
+	"github.com/insolar/assured-ledger/ledger-core/vanilla/throw"
+)
+
+type ExecutionChunk struct {
+	tp ExecutionChunkType
+
+	check  interface{}
+	update *executionupdate.ContractExecutionStateUpdate
+}
+
+type ExecutionChunkType int
+
+const (
+	Start ExecutionChunkType = iota
+	Continue
+	Abort
+)
+
+func (t ExecutionChunkType) String() string {
+	switch t {
+	case Start:
+		return "Start"
+	case Continue:
+		return "Continue"
+	case Abort:
+		return "Abort"
+	default:
+		return "Unknown"
+	}
+}
+
+type ExecutionMock struct {
+	key   interface{}
+	state *runState
+
+	pos    int
+	checks []ExecutionChunk
+}
+
+type ExecutionMockStartCheckFunc func(ctx execution.Context)
+type ExecutionMockContinueCheckFunc func(result []byte)
+type ExecutionMockAbortCheckFunc func()
+
+func (m *ExecutionMock) AddStart(fn ExecutionMockStartCheckFunc, returnValue *executionupdate.ContractExecutionStateUpdate) *ExecutionMock {
+	if len(m.checks) > 0 {
+		panic(throw.IllegalValue())
+	}
+	m.checks = append(m.checks, ExecutionChunk{
+		tp:     Start,
+		check:  fn,
+		update: returnValue,
+	})
+	return m
+}
+
+func (m *ExecutionMock) AddContinue(fn ExecutionMockContinueCheckFunc, returnValue *executionupdate.ContractExecutionStateUpdate) *ExecutionMock {
+	if len(m.checks) == 0 || m.checks[len(m.checks)-1].tp >= Abort {
+		panic(throw.IllegalValue())
+	}
+	m.checks = append(m.checks, ExecutionChunk{
+		tp:     Continue,
+		check:  fn,
+		update: returnValue,
+	})
+	return m
+}
+
+func (m *ExecutionMock) AddAbort(fn ExecutionMockAbortCheckFunc) *ExecutionMock {
+	if len(m.checks) == 0 || m.checks[len(m.checks)-1].tp >= Abort {
+		panic(throw.IllegalValue())
+	}
+	m.checks = append(m.checks, ExecutionChunk{
+		tp:     Abort,
+		check:  fn,
+		update: nil,
+	})
+	return m
+}
+
+func (m *ExecutionMock) next(expectedTp ExecutionChunkType) (*ExecutionChunk, error) {
+	var (
+		currentCheckPosition = m.pos
+	)
+
+	if len(m.checks) < currentCheckPosition {
+		return nil, throw.E("unexpected next step 1")
+	}
+
+	if m.checks[currentCheckPosition].tp != expectedTp {
+		return nil, throw.E("unexpected next step 2")
+	}
+
+	m.pos++
+
+	return &m.checks[currentCheckPosition], nil
+}
+
+func (m *ExecutionMock) minimockDone() bool {
+	var (
+		currentCheckPosition = m.pos
+	)
+
+	if len(m.checks) > currentCheckPosition {
+		panic(throw.IllegalState())
+	}
+
+	if len(m.checks) == currentCheckPosition {
+		return true
+	}
+
+	panic(throw.IllegalState())
+}

--- a/ledger-core/testutils/runner/logicless/service.go
+++ b/ledger-core/testutils/runner/logicless/service.go
@@ -1,0 +1,278 @@
+// Copyright 2020 Insolar Network Ltd.
+// All rights reserved.
+// This material is licensed under the Insolar License version 1.0,
+// available at https://github.com/insolar/assured-ledger/blob/master/LICENSE.md.
+
+package logicless
+
+import (
+	"context"
+	"sync/atomic"
+	"time"
+
+	"github.com/gojuno/minimock"
+
+	"github.com/insolar/assured-ledger/ledger-core/insolar/contract"
+	"github.com/insolar/assured-ledger/ledger-core/runner"
+	"github.com/insolar/assured-ledger/ledger-core/runner/call"
+	"github.com/insolar/assured-ledger/ledger-core/runner/execution"
+	"github.com/insolar/assured-ledger/ledger-core/runner/executionupdate"
+	"github.com/insolar/assured-ledger/ledger-core/testutils/runner/adapter"
+	"github.com/insolar/assured-ledger/ledger-core/vanilla/throw"
+)
+
+type runState struct {
+	id     call.ID
+	result *executionupdate.ContractExecutionStateUpdate
+}
+
+func (r runState) GetResult() *executionupdate.ContractExecutionStateUpdate {
+	return r.result
+}
+
+func (r runState) GetID() call.ID {
+	return r.id
+}
+
+type executionMapping struct {
+	byKey map[string]*ExecutionMock
+	byID  map[call.ID]*ExecutionMock
+}
+
+func (m *executionMapping) add(key string, val *ExecutionMock) {
+	if _, ok := m.byKey[key]; ok {
+		panic("already exists by key")
+	}
+	if _, ok := m.byID[val.state.GetID()]; ok {
+		panic("already exists by value")
+	}
+
+	m.byKey[key] = val
+	m.byID[val.state.GetID()] = val
+}
+
+func (m *executionMapping) getByKey(key string) (*ExecutionMock, bool) {
+	val, ok := m.byKey[key]
+	return val, ok
+}
+
+func (m *executionMapping) getByID(id call.ID) (*ExecutionMock, bool) {
+	val, ok := m.byID[id]
+	return val, ok
+}
+
+func (m *executionMapping) minimockDone() bool {
+	for _, executionMock := range m.byID {
+		if !executionMock.minimockDone() {
+			return false
+		}
+	}
+
+	return true
+}
+
+type ServiceMock struct {
+	ctx            context.Context
+	t              minimock.Tester
+	lastID         call.ID
+	keyConstructor func(execution execution.Context) string
+
+	executionMapping executionMapping
+	classifyMapping  ExecutionClassifyMock
+}
+
+func NewServiceMock(ctx context.Context, t minimock.Tester, keyConstructor func(execution execution.Context) string) *ServiceMock {
+	m := &ServiceMock{
+		ctx:            ctx,
+		t:              t,
+		lastID:         0,
+		keyConstructor: keyConstructor,
+
+		executionMapping: executionMapping{
+			byKey: make(map[string]*ExecutionMock),
+			byID:  make(map[call.ID]*ExecutionMock),
+		},
+		classifyMapping: ExecutionClassifyMock{
+			t:      t,
+			mapper: make(map[string]*ExecutionClassifyMockInstance),
+		},
+	}
+
+	if controller, ok := t.(minimock.MockController); ok {
+		controller.RegisterMocker(m)
+	}
+
+	return m
+}
+
+func (s *ServiceMock) CreateAdapter(ctx context.Context) runner.ServiceAdapter {
+	return adapter.NewImposter(ctx, s, 16)
+}
+
+func (s *ServiceMock) AddExecutionMock(key string) *ExecutionMock {
+	s.lastID++
+
+	executionMock := &ExecutionMock{
+		key:   key,
+		state: &runState{id: s.lastID},
+	}
+
+	s.executionMapping.add(key, executionMock)
+
+	return executionMock
+}
+
+func (s ServiceMock) ExecutionStart(execution execution.Context) runner.RunState {
+	executionMock, ok := s.executionMapping.getByKey(s.keyConstructor(execution))
+	if !ok {
+		panic(throw.NotImplemented())
+	}
+
+	executionMock.state.result = nil
+
+	executionChunk, err := executionMock.next(Start)
+	if err != nil {
+		s.t.Fatal(err.Error())
+
+		return nil
+	}
+
+	if fn := executionChunk.check; fn != nil {
+		checkFunc, ok := fn.(ExecutionMockStartCheckFunc)
+		if !ok {
+			panic(throw.IllegalState())
+		} else if checkFunc != nil {
+			checkFunc(execution)
+		}
+	}
+
+	executionMock.state.result = executionChunk.update
+
+	return executionMock.state
+}
+
+func (s ServiceMock) ExecutionContinue(run runner.RunState, outgoingResult []byte) {
+	executionMock, ok := s.executionMapping.getByID(run.GetID())
+	if !ok {
+		panic(throw.NotImplemented())
+	}
+
+	executionMock.state.result = nil
+
+	executionChunk, err := executionMock.next(Continue)
+	if err != nil {
+		s.t.Fatal(err.Error())
+
+		return
+	}
+
+	if fn := executionChunk.check; fn != nil {
+		checkFunc, ok := fn.(ExecutionMockContinueCheckFunc)
+		if !ok {
+			panic(throw.IllegalState())
+		} else if checkFunc != nil {
+			checkFunc(outgoingResult)
+		}
+	}
+
+	executionMock.state.result = executionChunk.update
+}
+
+func (s ServiceMock) ExecutionAbort(run runner.RunState) {
+	executionMock, ok := s.executionMapping.getByID(run.GetID())
+	if !ok {
+		panic(throw.NotImplemented())
+	}
+
+	executionMock.state.result = nil
+
+	executionChunk, err := executionMock.next(Abort)
+	if err != nil {
+		s.t.Fatal(err.Error())
+
+		return
+	}
+
+	if fn := executionChunk.check; fn != nil {
+		checkFunc, ok := fn.(ExecutionMockAbortCheckFunc)
+		if !ok {
+			panic(throw.IllegalState())
+		} else if checkFunc != nil {
+			checkFunc()
+		}
+	}
+
+	executionMock.state.result = nil
+}
+
+// MinimockFinish checks that all mocked methods have been called the expected number of times
+func (s ServiceMock) MinimockFinish() {
+	if !s.minimockDone() {
+		s.t.Fatal("failed to check")
+	}
+}
+
+// MinimockWait waits for all mocked methods to be called the expected number of times
+func (s ServiceMock) MinimockWait(timeout time.Duration) {
+	timeoutCh := time.After(timeout)
+	for {
+		if s.minimockDone() {
+			return
+		}
+		select {
+		case <-timeoutCh:
+			s.MinimockFinish()
+			return
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+}
+
+func (s ServiceMock) minimockDone() bool {
+	return s.classifyMapping.minimockDone() &&
+		s.executionMapping.minimockDone()
+}
+
+type ExecutionClassifyMockInstance struct {
+	count uint32
+
+	v1 contract.MethodIsolation
+	v2 error
+}
+
+type ExecutionClassifyMock struct {
+	t      minimock.Tester
+	mapper map[string]*ExecutionClassifyMockInstance
+}
+
+func (m *ExecutionClassifyMock) Set(key string, v1 contract.MethodIsolation, v2 error) *ExecutionClassifyMock {
+	if _, ok := m.mapper[key]; ok {
+		panic("key already exists")
+	}
+
+	m.mapper[key] = &ExecutionClassifyMockInstance{
+		v1: v1,
+		v2: v2,
+	}
+
+	return m
+}
+
+func (s ServiceMock) ExecutionClassify(execution execution.Context) (contract.MethodIsolation, error) {
+	if chunk, ok := s.classifyMapping.mapper[s.keyConstructor(execution)]; !ok {
+		chunk.count++
+		return chunk.v1, chunk.v2
+	}
+
+	panic("key not found")
+}
+
+func (m *ExecutionClassifyMock) minimockDone() bool {
+	for _, v := range m.mapper {
+		if atomic.LoadUint32(&v.count) == 0 {
+			return false
+		}
+	}
+
+	return true
+}

--- a/ledger-core/virtual/execute/execute.go
+++ b/ledger-core/virtual/execute/execute.go
@@ -51,13 +51,13 @@ type SMExecute struct {
 	executionNewState   *executionupdate.ContractExecutionStateUpdate
 	outgoingResult      []byte
 	deactivate          bool
-	run                 *runner.RunState
+	run                 runner.RunState
 	newObjectDescriptor descriptor.Object
 
 	methodIsolation contract.MethodIsolation
 
 	// dependencies
-	runner        *runner.ServiceAdapter
+	runner        runner.ServiceAdapter
 	messageSender messageSenderAdapter.MessageSender
 	pulseSlot     *conveyor.PulseSlot
 
@@ -399,7 +399,7 @@ func (s *SMExecute) migrateDuringExecution(ctx smachine.MigrationContext) smachi
 }
 
 func (s *SMExecute) stepExecuteStart(ctx smachine.ExecutionContext) smachine.StateUpdate {
-	return s.runner.PrepareExecutionStart(ctx, s.execution, func(state *runner.RunState) {
+	return s.runner.PrepareExecutionStart(ctx, s.execution, func(state runner.RunState) {
 		s.run = state
 	}).DelayedStart().Sleep().ThenJump(s.stepExecuteDecideNextStep)
 }

--- a/ledger-core/virtual/integration/mock/defaultchecker.go
+++ b/ledger-core/virtual/integration/mock/defaultchecker.go
@@ -1,0 +1,39 @@
+// Copyright 2020 Insolar Network Ltd.
+// All rights reserved.
+// This material is licensed under the Insolar License version 1.0,
+// available at https://github.com/insolar/assured-ledger/blob/master/LICENSE.md.
+
+package mock
+
+import (
+	"context"
+
+	"github.com/ThreeDotsLabs/watermill/message"
+)
+
+var _ Checker = &DefaultPublishChecker{}
+
+type DefaultPublishChecker struct {
+	checkerFn CheckerFn
+}
+
+func NewDefaultPublishChecker(fn CheckerFn) *DefaultPublishChecker {
+	return &DefaultPublishChecker{
+		checkerFn: fn,
+	}
+}
+
+func (p *DefaultPublishChecker) CheckMessages(topic string, messages ...*message.Message) error {
+	return p.checkerFn(topic, messages...)
+}
+
+func NewResenderPublishChecker(ctx context.Context, sender Sender) *DefaultPublishChecker {
+	return &DefaultPublishChecker{
+		checkerFn: func(topic string, messages ...*message.Message) error {
+			for _, msg := range messages {
+				sender.SendMessage(ctx, msg)
+			}
+			return nil
+		},
+	}
+}

--- a/ledger-core/virtual/integration/mock/publisher.go
+++ b/ledger-core/virtual/integration/mock/publisher.go
@@ -11,17 +11,22 @@ import (
 	"time"
 
 	"github.com/ThreeDotsLabs/watermill/message"
+	"github.com/gojuno/minimock"
 )
 
 var _ message.Publisher = &PublisherMock{}
 
 type CheckerFn func(topic string, messages ...*message.Message) error
 
+type Checker interface {
+	CheckMessages(topic string, messages ...*message.Message) error
+}
+
 type PublisherMock struct {
 	lock            sync.RWMutex
 	messageNotifier chan struct{}
 	messageCounter  int
-	checker         CheckerFn
+	checker         Checker
 	closed          bool
 }
 
@@ -49,6 +54,10 @@ func (p *PublisherMock) messageCountUpdate(count int) {
 	p.messageCounter += count
 }
 
+func (p *PublisherMock) GetCount() int {
+	return p.messageCounter
+}
+
 func (p *PublisherMock) WaitCount(count int, timeout time.Duration) bool {
 	for {
 		if p.messageCount() >= count {
@@ -65,19 +74,34 @@ func (p *PublisherMock) WaitCount(count int, timeout time.Duration) bool {
 }
 
 func (p *PublisherMock) SetResenderMode(ctx context.Context, sender Sender) {
-	p.SetChecker(func(topic string, messages ...*message.Message) error {
-		for _, msg := range messages {
-			sender.SendMessage(ctx, msg)
-		}
-		return nil
-	})
+	p.lock.Lock()
+	defer p.lock.Unlock()
+
+	p.checker = NewResenderPublishChecker(ctx, sender)
+}
+
+func (p *PublisherMock) SetTypedChecker(ctx context.Context, t minimock.Tester, sender Sender) *TypePublishChecker {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+
+	checker := NewTypePublishChecker(ctx, t, sender)
+	p.checker = checker
+
+	return checker
+}
+
+func (p *PublisherMock) SetBaseChecker(fn Checker) {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+
+	p.checker = fn
 }
 
 func (p *PublisherMock) SetChecker(fn CheckerFn) {
 	p.lock.Lock()
 	defer p.lock.Unlock()
 
-	p.checker = fn
+	p.checker = NewDefaultPublishChecker(fn)
 }
 
 func (p *PublisherMock) getChecker() CheckerFn {
@@ -92,7 +116,7 @@ func (p *PublisherMock) getChecker() CheckerFn {
 		panic("checker function is empty")
 	}
 
-	return p.checker
+	return p.checker.CheckMessages
 }
 
 func (p *PublisherMock) Publish(topic string, messages ...*message.Message) error {

--- a/ledger-core/virtual/integration/mock/typepublishchecker.go
+++ b/ledger-core/virtual/integration/mock/typepublishchecker.go
@@ -1,0 +1,468 @@
+// Copyright 2020 Insolar Network Ltd.
+// All rights reserved.
+// This material is licensed under the Insolar License version 1.0,
+// available at https://github.com/insolar/assured-ledger/blob/master/LICENSE.md.
+
+package mock
+
+import (
+	"context"
+	mm_time "time"
+
+	"github.com/ThreeDotsLabs/watermill/message"
+	"github.com/gojuno/minimock"
+
+	"github.com/insolar/assured-ledger/ledger-core/insolar/payload"
+	"github.com/insolar/assured-ledger/ledger-core/vanilla/atomickit"
+)
+
+// ============================================================================
+
+type VCallRequestHandler func(*payload.VCallRequest) bool
+type PubVCallRequestMock struct{ parent *TypePublishChecker }
+
+func (p PubVCallRequestMock) ExpectedCount(count int) PubVCallRequestMock {
+	p.parent.Handlers.VCallRequest.touched = true
+	p.parent.Handlers.VCallRequest.expectedCount = count
+	return p
+}
+
+func (p PubVCallRequestMock) Set(handler VCallRequestHandler) PubVCallRequestMock {
+	p.parent.Handlers.VCallRequest.touched = true
+	p.parent.Handlers.VCallRequest.handler = handler
+	if p.parent.Handlers.VCallRequest.expectedCount == 0 {
+		p.parent.Handlers.VCallRequest.expectedCount = -1
+	}
+	return p
+}
+
+func (p PubVCallRequestMock) SetResend() PubVCallRequestMock {
+	p.parent.Handlers.VCallRequest.touched = true
+	p.parent.Handlers.VCallRequest.handler = func(*payload.VCallRequest) bool { return true }
+	return p
+}
+
+// ============================================================================
+
+type VCallResultHandler func(*payload.VCallResult) bool
+type PubVCallResultMock struct{ parent *TypePublishChecker }
+
+func (p PubVCallResultMock) ExpectedCount(count int) PubVCallResultMock {
+	p.parent.Handlers.VCallResult.touched = true
+	p.parent.Handlers.VCallResult.expectedCount = count
+	return p
+}
+
+func (p PubVCallResultMock) Set(handler VCallResultHandler) PubVCallResultMock {
+	p.parent.Handlers.VCallResult.touched = true
+	p.parent.Handlers.VCallResult.handler = handler
+	if p.parent.Handlers.VCallResult.expectedCount == 0 {
+		p.parent.Handlers.VCallResult.expectedCount = -1
+	}
+	return p
+}
+
+func (p PubVCallResultMock) SetResend() PubVCallResultMock {
+	p.parent.Handlers.VCallResult.touched = true
+	p.parent.Handlers.VCallResult.handler = func(*payload.VCallResult) bool { return true }
+	return p
+}
+
+// ============================================================================
+
+type VDelegatedCallRequestHandler func(*payload.VDelegatedCallRequest) bool
+type PubVDelegatedCallRequestMock struct{ parent *TypePublishChecker }
+
+func (p PubVDelegatedCallRequestMock) ExpectedCount(count int) PubVDelegatedCallRequestMock {
+	p.parent.Handlers.VDelegatedCallRequest.touched = true
+	p.parent.Handlers.VDelegatedCallRequest.expectedCount = count
+	return p
+}
+
+func (p PubVDelegatedCallRequestMock) Set(handler VDelegatedCallRequestHandler) PubVDelegatedCallRequestMock {
+	p.parent.Handlers.VDelegatedCallRequest.touched = true
+	p.parent.Handlers.VDelegatedCallRequest.handler = handler
+	if p.parent.Handlers.VDelegatedCallRequest.expectedCount == 0 {
+		p.parent.Handlers.VDelegatedCallRequest.expectedCount = -1
+	}
+	return p
+}
+
+func (p PubVDelegatedCallRequestMock) SetResend() PubVDelegatedCallRequestMock {
+	p.parent.Handlers.VDelegatedCallRequest.touched = true
+	p.parent.Handlers.VDelegatedCallRequest.handler = func(*payload.VDelegatedCallRequest) bool { return true }
+	return p
+}
+
+// ============================================================================
+
+type VDelegatedCallResponseHandler func(*payload.VDelegatedCallResponse) bool
+type PubVDelegatedCallResponseMock struct{ parent *TypePublishChecker }
+
+func (p PubVDelegatedCallResponseMock) ExpectedCount(count int) PubVDelegatedCallResponseMock {
+	p.parent.Handlers.VDelegatedCallResponse.touched = true
+	p.parent.Handlers.VDelegatedCallResponse.expectedCount = count
+	return p
+}
+
+func (p PubVDelegatedCallResponseMock) Set(handler VDelegatedCallResponseHandler) PubVDelegatedCallResponseMock {
+	p.parent.Handlers.VDelegatedCallResponse.touched = true
+	p.parent.Handlers.VDelegatedCallResponse.handler = handler
+	if p.parent.Handlers.VDelegatedCallResponse.expectedCount == 0 {
+		p.parent.Handlers.VDelegatedCallResponse.expectedCount = -1
+	}
+	return p
+}
+
+func (p PubVDelegatedCallResponseMock) SetResend() PubVDelegatedCallResponseMock {
+	p.parent.Handlers.VDelegatedCallResponse.touched = true
+	p.parent.Handlers.VDelegatedCallResponse.handler = func(*payload.VDelegatedCallResponse) bool { return true }
+	return p
+}
+
+// ============================================================================
+
+type VDelegatedRequestFinishedHandler func(*payload.VDelegatedRequestFinished) bool
+type PubVDelegatedRequestFinishedMock struct{ parent *TypePublishChecker }
+
+func (p PubVDelegatedRequestFinishedMock) ExpectedCount(count int) PubVDelegatedRequestFinishedMock {
+	p.parent.Handlers.VDelegatedRequestFinished.touched = true
+	p.parent.Handlers.VDelegatedRequestFinished.expectedCount = count
+	return p
+}
+
+func (p PubVDelegatedRequestFinishedMock) Set(handler VDelegatedRequestFinishedHandler) PubVDelegatedRequestFinishedMock {
+	p.parent.Handlers.VDelegatedRequestFinished.touched = true
+	p.parent.Handlers.VDelegatedRequestFinished.handler = handler
+	if p.parent.Handlers.VDelegatedRequestFinished.expectedCount == 0 {
+		p.parent.Handlers.VDelegatedRequestFinished.expectedCount = -1
+	}
+	return p
+}
+
+func (p PubVDelegatedRequestFinishedMock) SetResend() PubVDelegatedRequestFinishedMock {
+	p.parent.Handlers.VDelegatedRequestFinished.touched = true
+	p.parent.Handlers.VDelegatedRequestFinished.handler = func(*payload.VDelegatedRequestFinished) bool { return true }
+	return p
+}
+
+// ============================================================================
+
+type VStateRequestHandler func(*payload.VStateRequest) bool
+type PubVStateRequestMock struct{ parent *TypePublishChecker }
+
+func (p PubVStateRequestMock) ExpectedCount(count int) PubVStateRequestMock {
+	p.parent.Handlers.VStateRequest.touched = true
+	p.parent.Handlers.VStateRequest.expectedCount = count
+	return p
+}
+
+func (p PubVStateRequestMock) Set(handler VStateRequestHandler) PubVStateRequestMock {
+	p.parent.Handlers.VStateRequest.touched = true
+	p.parent.Handlers.VStateRequest.handler = handler
+	if p.parent.Handlers.VStateRequest.expectedCount == 0 {
+		p.parent.Handlers.VStateRequest.expectedCount = -1
+	}
+	return p
+}
+
+func (p PubVStateRequestMock) SetResend() PubVStateRequestMock {
+	p.parent.Handlers.VStateRequest.touched = true
+	p.parent.Handlers.VStateRequest.handler = func(*payload.VStateRequest) bool { return true }
+	return p
+}
+
+// ============================================================================
+
+type VStateReportHandler func(*payload.VStateReport) bool
+type PubVStateReportMock struct{ parent *TypePublishChecker }
+
+func (p PubVStateReportMock) ExpectedCount(count int) PubVStateReportMock {
+	p.parent.Handlers.VStateReport.touched = true
+	p.parent.Handlers.VStateReport.expectedCount = count
+	return p
+}
+
+func (p PubVStateReportMock) Set(handler VStateReportHandler) PubVStateReportMock {
+	p.parent.Handlers.VStateReport.touched = true
+	p.parent.Handlers.VStateReport.handler = handler
+	if p.parent.Handlers.VStateReport.expectedCount == 0 {
+		p.parent.Handlers.VStateReport.expectedCount = -1
+	}
+	return p
+}
+
+func (p PubVStateReportMock) SetResend() PubVStateReportMock {
+	p.parent.Handlers.VStateReport.touched = true
+	p.parent.Handlers.VStateReport.handler = func(*payload.VStateReport) bool { return true }
+	return p
+}
+
+// ============================================================================
+
+type TypePublishCheckerHandlers struct {
+	VCallRequest struct {
+		touched       bool
+		count         atomickit.Int
+		expectedCount int
+		handler       VCallRequestHandler
+	}
+	VCallResult struct {
+		touched       bool
+		count         atomickit.Int
+		expectedCount int
+		handler       VCallResultHandler
+	}
+	VDelegatedCallRequest struct {
+		touched       bool
+		count         atomickit.Int
+		expectedCount int
+		handler       VDelegatedCallRequestHandler
+	}
+	VDelegatedCallResponse struct {
+		touched       bool
+		count         atomickit.Int
+		expectedCount int
+		handler       VDelegatedCallResponseHandler
+	}
+	VDelegatedRequestFinished struct {
+		touched       bool
+		count         atomickit.Int
+		expectedCount int
+		handler       VDelegatedRequestFinishedHandler
+	}
+	VStateRequest struct {
+		touched       bool
+		count         atomickit.Int
+		expectedCount int
+		handler       VStateRequestHandler
+	}
+	VStateReport struct {
+		touched       bool
+		count         atomickit.Int
+		expectedCount int
+		handler       VStateReportHandler
+	}
+
+	BaseMessage struct {
+		handler func(message *message.Message)
+	}
+}
+
+type TypePublishChecker struct {
+	t             minimock.Tester
+	ctx           context.Context
+	defaultResend bool
+	resend        func(ctx context.Context, msg *message.Message)
+
+	Handlers TypePublishCheckerHandlers
+
+	VCallRequest              PubVCallRequestMock
+	VCallResult               PubVCallResultMock
+	VDelegatedCallRequest     PubVDelegatedCallRequestMock
+	VDelegatedCallResponse    PubVDelegatedCallResponseMock
+	VDelegatedRequestFinished PubVDelegatedRequestFinishedMock
+	VStateRequest             PubVStateRequestMock
+	VStateReport              PubVStateReportMock
+}
+
+func NewTypePublishChecker(ctx context.Context, t minimock.Tester, sender Sender) *TypePublishChecker {
+	checker := &TypePublishChecker{
+		t:             t,
+		ctx:           ctx,
+		defaultResend: false,
+		resend:        sender.SendMessage,
+	}
+
+	checker.VCallRequest = PubVCallRequestMock{parent: checker}
+	checker.VCallResult = PubVCallResultMock{parent: checker}
+	checker.VDelegatedCallRequest = PubVDelegatedCallRequestMock{parent: checker}
+	checker.VDelegatedCallResponse = PubVDelegatedCallResponseMock{parent: checker}
+	checker.VDelegatedRequestFinished = PubVDelegatedRequestFinishedMock{parent: checker}
+	checker.VStateRequest = PubVStateRequestMock{parent: checker}
+	checker.VStateReport = PubVStateReportMock{parent: checker}
+
+	if controller, ok := t.(minimock.MockController); ok {
+		controller.RegisterMocker(checker)
+	}
+
+	return checker
+}
+
+func (p *TypePublishChecker) CheckMessages(topic string, messages ...*message.Message) error {
+	for _, msg := range messages {
+		p.checkMessage(p.ctx, msg)
+	}
+
+	return nil
+}
+
+func (p *TypePublishChecker) checkMessage(ctx context.Context, msg *message.Message) {
+	basePayload, err := payload.UnmarshalFromMeta(msg.Payload)
+	if err != nil {
+		return
+	}
+
+	var resend bool
+
+	switch payload := basePayload.(type) {
+	case *payload.VCallRequest:
+		hdlStruct := &p.Handlers.VCallRequest
+
+		resend = p.defaultResend
+
+		if hdlStruct.handler != nil {
+			resend = hdlStruct.handler(payload)
+		} else if !p.defaultResend && !hdlStruct.touched {
+			p.t.Fatalf("unexpected %T payload", payload)
+			return
+		}
+
+		hdlStruct.count.Add(1)
+
+	case *payload.VCallResult:
+		hdlStruct := &p.Handlers.VCallResult
+
+		resend = p.defaultResend
+
+		if hdlStruct.handler != nil {
+			resend = hdlStruct.handler(payload)
+		} else if !p.defaultResend && !hdlStruct.touched {
+			p.t.Fatalf("unexpected %T payload", payload)
+			return
+		}
+
+		hdlStruct.count.Add(1)
+
+	case *payload.VDelegatedCallRequest:
+		hdlStruct := &p.Handlers.VDelegatedCallRequest
+
+		resend = p.defaultResend
+
+		if hdlStruct.handler != nil {
+			resend = hdlStruct.handler(payload)
+		} else if !p.defaultResend && !hdlStruct.touched {
+			p.t.Fatalf("unexpected %T payload", payload)
+			return
+		}
+
+		hdlStruct.count.Add(1)
+
+	case *payload.VDelegatedCallResponse:
+		hdlStruct := &p.Handlers.VDelegatedCallResponse
+
+		resend = p.defaultResend
+
+		if hdlStruct.handler != nil {
+			resend = hdlStruct.handler(payload)
+		} else if !p.defaultResend && !hdlStruct.touched {
+			p.t.Fatalf("unexpected %T payload", payload)
+			return
+		}
+
+		hdlStruct.count.Add(1)
+
+	case *payload.VDelegatedRequestFinished:
+		hdlStruct := &p.Handlers.VDelegatedRequestFinished
+
+		resend = p.defaultResend
+
+		if hdlStruct.handler != nil {
+			resend = hdlStruct.handler(payload)
+		} else if !p.defaultResend && !hdlStruct.touched {
+			p.t.Fatalf("unexpected %T payload", payload)
+			return
+		}
+
+		hdlStruct.count.Add(1)
+
+	case *payload.VStateRequest:
+		hdlStruct := &p.Handlers.VStateRequest
+
+		resend = p.defaultResend
+
+		if hdlStruct.handler != nil {
+			resend = hdlStruct.handler(payload)
+		} else if !p.defaultResend && !hdlStruct.touched {
+			p.t.Fatalf("unexpected %T payload", payload)
+			return
+		}
+
+		hdlStruct.count.Add(1)
+
+	case *payload.VStateReport:
+		hdlStruct := &p.Handlers.VStateReport
+
+		resend = p.defaultResend
+
+		if hdlStruct.handler != nil {
+			resend = hdlStruct.handler(payload)
+		} else if !p.defaultResend && !hdlStruct.touched {
+			p.t.Fatalf("unexpected %T payload", payload)
+			return
+		}
+
+		hdlStruct.count.Add(1)
+
+	default:
+		p.t.Fatalf("unexpected %T payload", basePayload)
+		return
+	}
+
+	if resend {
+		p.resend(ctx, msg)
+	}
+}
+
+func (p *TypePublishChecker) SetDefaultResend(flag bool) *TypePublishChecker {
+	p.defaultResend = flag
+	return p
+}
+
+func (p *TypePublishChecker) minimockDone() bool {
+	if hdl := p.Handlers.VCallRequest; hdl.expectedCount >= 0 && !(p.defaultResend && hdl.expectedCount == 0) {
+		return hdl.count.Load() == hdl.expectedCount
+	}
+	if hdl := p.Handlers.VCallResult; hdl.expectedCount >= 0 && !(p.defaultResend && hdl.expectedCount == 0) {
+		return hdl.count.Load() == hdl.expectedCount
+	}
+	if hdl := p.Handlers.VDelegatedCallRequest; hdl.expectedCount >= 0 && !(p.defaultResend && hdl.expectedCount == 0) {
+		return hdl.count.Load() == hdl.expectedCount
+	}
+	if hdl := p.Handlers.VDelegatedCallResponse; hdl.expectedCount >= 0 && !(p.defaultResend && hdl.expectedCount == 0) {
+		return hdl.count.Load() == hdl.expectedCount
+	}
+	if hdl := p.Handlers.VDelegatedRequestFinished; hdl.expectedCount >= 0 && !(p.defaultResend && hdl.expectedCount == 0) {
+		return hdl.count.Load() == hdl.expectedCount
+	}
+	if hdl := p.Handlers.VStateRequest; hdl.expectedCount >= 0 && !(p.defaultResend && hdl.expectedCount == 0) {
+		return hdl.count.Load() == hdl.expectedCount
+	}
+	if hdl := p.Handlers.VStateReport; hdl.expectedCount >= 0 && !(p.defaultResend && hdl.expectedCount == 0) {
+		return hdl.count.Load() == hdl.expectedCount
+	}
+	return true
+}
+
+// MinimockFinish checks that all mocked methods have been called the expected number of times
+func (p *TypePublishChecker) MinimockFinish() {
+	if !p.minimockDone() {
+		p.t.Fatal("failed conditions on TypePublishChecker")
+	}
+}
+
+// MinimockWait waits for all mocked methods to be called the expected number of times
+func (p *TypePublishChecker) MinimockWait(timeout mm_time.Duration) {
+	timeoutCh := mm_time.After(timeout)
+	for {
+		if p.minimockDone() {
+			return
+		}
+		select {
+		case <-timeoutCh:
+			p.MinimockFinish()
+			return
+		case <-mm_time.After(10 * mm_time.Millisecond):
+		}
+	}
+}

--- a/ledger-core/virtual/integration/utils/helper.go
+++ b/ledger-core/virtual/integration/utils/helper.go
@@ -1,0 +1,90 @@
+// Copyright 2020 Insolar Network Ltd.
+// All rights reserved.
+// This material is licensed under the Insolar License version 1.0,
+// available at https://github.com/insolar/assured-ledger/blob/master/LICENSE.md.
+
+package utils
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/insolar/assured-ledger/ledger-core/insolar"
+	"github.com/insolar/assured-ledger/ledger-core/insolar/contract"
+	"github.com/insolar/assured-ledger/ledger-core/insolar/payload"
+	"github.com/insolar/assured-ledger/ledger-core/reference"
+	"github.com/insolar/assured-ledger/ledger-core/runner/execution"
+	"github.com/insolar/assured-ledger/ledger-core/runner/executionupdate"
+	"github.com/insolar/assured-ledger/ledger-core/runner/requestresult"
+	"github.com/insolar/assured-ledger/ledger-core/testutils/gen"
+	"github.com/insolar/assured-ledger/ledger-core/testutils/runner/logicless"
+)
+
+type Helper struct {
+	server *Server
+	class  reference.Global
+}
+
+func NewHelper(srv *Server) *Helper {
+	return &Helper{
+		server: srv,
+		class:  gen.UniqueReference(),
+	}
+}
+
+func (h *Helper) GetObjectClass() reference.Global {
+	return h.class
+}
+
+func (h *Helper) calculateOutgoing(pl payload.VCallRequest) reference.Global {
+	return reference.NewRecordOf(pl.Callee, pl.CallOutgoing)
+}
+
+func (h *Helper) CreateObject(ctx context.Context, t *testing.T) reference.Global {
+	var (
+		pn          = h.server.GetPulse().PulseNumber
+		isolation   = contract.ConstructorIsolation()
+		plArguments = insolar.MustSerialize([]interface{}{})
+	)
+
+	pl := payload.VCallRequest{
+		CallType:       payload.CTConstructor,
+		CallFlags:      payload.BuildCallFlags(isolation.Interference, isolation.State),
+		Caller:         h.server.GlobalCaller(),
+		Callee:         h.class,
+		CallSiteMethod: "New",
+		CallOutgoing:   gen.UniqueIDWithPulse(pn),
+		Arguments:      plArguments,
+	}
+	msg := NewRequestWrapper(pn, &pl).Finalize()
+	objectReference := h.calculateOutgoing(pl)
+
+	{
+		keyExtractor := func(ctx execution.Context) string { return ctx.Outgoing.String() }
+		mockedRunner := logicless.NewServiceMock(ctx, t, keyExtractor)
+		h.server.ReplaceRunner(mockedRunner)
+
+		serializedResult := SerializeCreateWalletResultOK(objectReference)
+
+		result := requestresult.New(serializedResult, objectReference)
+		result.SetActivate(reference.Global{}, h.class, CreateWallet(initialBalance))
+
+		executionMock := mockedRunner.AddExecutionMock(objectReference.String())
+		executionMock.AddStart(nil, &executionupdate.ContractExecutionStateUpdate{
+			Type:   executionupdate.Done,
+			Result: result,
+		})
+	}
+
+	typedChecker := h.server.PublisherMock.SetTypedChecker(ctx, t, h.server)
+	typedChecker.VCallResult.ExpectedCount(1)
+
+	messagesBefore := h.server.PublisherMock.GetCount()
+	h.server.SendMessage(ctx, msg)
+	if !h.server.PublisherMock.WaitCount(messagesBefore+1, 10*time.Second) {
+		panic("failed to wait for VCallResult")
+	}
+
+	return objectReference
+}

--- a/ledger-core/virtual/integration/utils/server.go
+++ b/ledger-core/virtual/integration/utils/server.go
@@ -38,7 +38,7 @@ import (
 
 type Server struct {
 	pulseLock sync.Mutex
-	dataLock sync.Mutex
+	dataLock  sync.Mutex
 
 	// real components
 	virtual       *virtual.Dispatcher
@@ -50,10 +50,10 @@ type Server struct {
 	JetCoordinatorMock *jet.AffinityHelperMock
 	pulseGenerator     *testutils.PulseGenerator
 	pulseStorage       *pulsestor.StorageMem
-	pulseManager       pulsestor.Manager
+	pulseManager       *pulsemanager.PulseManager
 
-	cycleFn 		   ConveyorCycleFunc
-	activeCount        atomickit.Uint32
+	cycleFn     ConveyorCycleFunc
+	activeCount atomickit.Uint32
 
 	// components for testing http api
 	testWalletServer *testwalletapi.TestWalletServer
@@ -65,14 +65,18 @@ type Server struct {
 type ConveyorCycleFunc func(c *conveyor.PulseConveyor, idle bool)
 
 func NewServer(ctx context.Context, t *testing.T) (*Server, context.Context) {
-	return newServerExt(ctx, t, false)
+	return newServerExt(ctx, t, false, true)
 }
 
 func NewServerIgnoreLogErrors(ctx context.Context, t *testing.T) (*Server, context.Context) {
-	return newServerExt(ctx, t, true)
+	return newServerExt(ctx, t, true, true)
 }
 
-func newServerExt(ctx context.Context, t *testing.T, suppressLogError bool) (*Server, context.Context) {
+func NewUninitializedServer(ctx context.Context, t *testing.T) (*Server, context.Context) {
+	return newServerExt(ctx, t, true, false)
+}
+
+func newServerExt(ctx context.Context, t *testing.T, suppressLogError bool, init bool) (*Server, context.Context) {
 	inslogger.SetTestOutput(t, suppressLogError)
 
 	if ctx == nil {
@@ -135,24 +139,30 @@ func newServerExt(ctx context.Context, t *testing.T, suppressLogError bool) (*Se
 	virtualDispatcher.MessageSender = messageSender
 	virtualDispatcher.TokenService = token.NewService(ctx, s.caller)
 	virtualDispatcher.CycleFn = s.onCycle
+	s.virtual = virtualDispatcher
 
 	if convlog.UseTextConvLog {
 		virtualDispatcher.MachineLogger = convlog.MachineLogger{}
 	}
-	if err := virtualDispatcher.Init(ctx); err != nil {
-		panic(err)
-	}
-
-	s.virtual = virtualDispatcher
-
-	PulseManager.AddDispatcher(s.virtual.FlowDispatcher)
-	s.IncrementPulse(ctx)
 
 	// re HTTP testing
 	testWalletAPIConfig := configuration.TestWalletAPI{Address: "very naughty address"}
 	s.testWalletServer = testwalletapi.NewTestWalletServer(testWalletAPIConfig, virtualDispatcher, Pulses)
 
+	if init {
+		s.Init(ctx)
+	}
+
 	return &s, ctx
+}
+
+func (s *Server) Init(ctx context.Context) {
+	if err := s.virtual.Init(ctx); err != nil {
+		panic(err)
+	}
+
+	s.pulseManager.AddDispatcher(s.virtual.FlowDispatcher)
+	s.IncrementPulse(ctx)
 }
 
 func (s *Server) GetPulse() pulsestor.Pulse {
@@ -199,6 +209,10 @@ func (s *Server) SendMessage(_ context.Context, msg *message.Message) {
 	if err := s.virtual.FlowDispatcher.Process(msg); err != nil {
 		panic(err)
 	}
+}
+
+func (s *Server) ReplaceRunner(svc runner.Service) {
+	s.virtual.Runner = svc
 }
 
 func (s *Server) ReplaceMachinesManager(manager machine.Manager) {
@@ -251,4 +265,3 @@ func (s *Server) waitIdleConveyor(checkActive bool) {
 func (s *Server) ResetActiveConveyorFlag() {
 	s.activeCount.Store(0)
 }
-

--- a/ledger-core/virtual/integration/utils/wallet.go
+++ b/ledger-core/virtual/integration/utils/wallet.go
@@ -1,0 +1,44 @@
+// Copyright 2020 Insolar Network Ltd.
+// All rights reserved.
+// This material is licensed under the Insolar License version 1.0,
+// available at https://github.com/insolar/assured-ledger/blob/master/LICENSE.md.
+
+package utils
+
+import (
+	"github.com/insolar/assured-ledger/ledger-core/insolar"
+	"github.com/insolar/assured-ledger/ledger-core/reference"
+	"github.com/insolar/assured-ledger/ledger-core/vanilla/throw"
+)
+
+const initialBalance uint32 = 1000000000
+
+type Wallet struct {
+	Balance uint32
+}
+
+func (w Wallet) Serialize() []byte {
+	walletBytes, err := insolar.Serialize(w)
+	if err != nil {
+		panic(throw.W(err, "failed to serialize wallet"))
+	}
+	return walletBytes
+}
+
+func DeserializeWallet(walletBytes []byte) Wallet {
+	wallet := Wallet{}
+	insolar.MustDeserialize(walletBytes, &wallet)
+	return wallet
+}
+
+func CreateWallet(balance uint32) []byte {
+	return Wallet{Balance: balance}.Serialize()
+}
+
+func SerializeCreateWalletResultOK(objectRef reference.Global) []byte {
+	resultBytes, err := insolar.Serialize([]interface{}{objectRef, error(nil)})
+	if err != nil {
+		panic(throw.W(err, "failed to serialize OK result"))
+	}
+	return resultBytes
+}

--- a/ledger-core/virtual/statemachine/logger_step.go
+++ b/ledger-core/virtual/statemachine/logger_step.go
@@ -100,7 +100,6 @@ func (c ConveyorLogger) LogAdapter(data smachine.StepLoggerData, adapterID smach
 }
 
 func (c ConveyorLogger) LogUpdate(data smachine.StepLoggerData, updateData smachine.StepLoggerUpdateData) {
-
 	if _, ok := data.Declaration.(*conveyor.PulseSlotMachine); ok {
 		return
 	}

--- a/ledger-core/virtual/testutils/slotdebugger/stepmachine.go
+++ b/ledger-core/virtual/testutils/slotdebugger/stepmachine.go
@@ -42,6 +42,6 @@ func (c *VirtualStepController) PrepareRunner(ctx context.Context, mc *minimock.
 	runnerService.Manager = c.MachineManager
 	runnerService.Cache = c.RunnerDescriptorCache.Mock()
 
-	runnerAdapter := runner.CreateRunnerService(ctx, runnerService)
-	c.SlotMachine.AddDependency(runnerAdapter)
+	runnerAdapter := runnerService.CreateAdapter(ctx)
+	c.SlotMachine.AddInterfaceDependency(&runnerAdapter)
 }

--- a/ledger-core/virtual/virtual.go
+++ b/ledger-core/virtual/virtual.go
@@ -17,7 +17,6 @@ import (
 	messageSenderAdapter "github.com/insolar/assured-ledger/ledger-core/network/messagesender/adapter"
 	"github.com/insolar/assured-ledger/ledger-core/pulse"
 	"github.com/insolar/assured-ledger/ledger-core/runner"
-	runnerAdapter "github.com/insolar/assured-ledger/ledger-core/runner"
 	"github.com/insolar/assured-ledger/ledger-core/vanilla/throw"
 	"github.com/insolar/assured-ledger/ledger-core/virtual/handlers"
 	"github.com/insolar/assured-ledger/ledger-core/virtual/object"
@@ -49,11 +48,11 @@ type Dispatcher struct {
 	CycleFn  conveyor.PulseConveyorCycleFunc
 
 	// Components
-	Runner        *runner.DefaultService
+	Runner        runner.Service
 	MessageSender messagesender.Service
 	TokenService  token.Service
 
-	runnerAdapter        *runnerAdapter.ServiceAdapter
+	runnerAdapter        runner.ServiceAdapter
 	messageSenderAdapter messageSenderAdapter.MessageSender
 
 	stopFunc context.CancelFunc
@@ -89,10 +88,10 @@ func (lr *Dispatcher) Init(ctx context.Context) error {
 		MaxPastPulseAge:       1000,
 	}, defaultHandlers, nil)
 
-	lr.runnerAdapter = runner.CreateRunnerService(ctx, lr.Runner)
+	lr.runnerAdapter = lr.Runner.CreateAdapter(ctx)
 	lr.messageSenderAdapter = messageSenderAdapter.CreateMessageSendService(ctx, lr.MessageSender)
 
-	lr.Conveyor.AddDependency(lr.runnerAdapter)
+	lr.Conveyor.AddInterfaceDependency(&lr.runnerAdapter)
 	lr.Conveyor.AddInterfaceDependency(&lr.messageSenderAdapter)
 	lr.Conveyor.AddInterfaceDependency(&lr.TokenService)
 


### PR DESCRIPTION
* also implement simplier publisher checker

Example of test with both features:

``` go
// Copyright 2020 Insolar Network Ltd.
// All rights reserved.
// This material is licensed under the Insolar License version 1.0,
// available at https://github.com/insolar/assured-ledger/blob/master/LICENSE.md.

package integration

import (
	"testing"
	"time"

	"github.com/gojuno/minimock"

	"github.com/insolar/assured-ledger/ledger-core/insolar"
	"github.com/insolar/assured-ledger/ledger-core/insolar/contract"
	"github.com/insolar/assured-ledger/ledger-core/insolar/payload"
	"github.com/insolar/assured-ledger/ledger-core/reference"
	"github.com/insolar/assured-ledger/ledger-core/runner/execution"
	"github.com/insolar/assured-ledger/ledger-core/runner/executionevent"
	"github.com/insolar/assured-ledger/ledger-core/runner/executionupdate"
	"github.com/insolar/assured-ledger/ledger-core/runner/requestresult"
	"github.com/insolar/assured-ledger/ledger-core/testutils/gen"
	"github.com/insolar/assured-ledger/ledger-core/testutils/runner/logicless"
	"github.com/insolar/assured-ledger/ledger-core/virtual/integration/utils"
)

func calculateOutgoing(request payload.VCallRequest) reference.Global {
	return reference.NewRecordOf(request.Callee, request.CallOutgoing)
}

func TestVirtual_WithOutgoing(t *testing.T) {
	var (
		mc = minimock.NewController(t)
	)

	server, ctx := utils.NewServer(nil, t, false)
	defer server.Stop()

	keyExtractor := func(ctx execution.Context) string { return ctx.Outgoing.String() }
	mockedRunner := logicless.NewServiceMock(ctx, mc, keyExtractor)
	server.ReplaceRunner(mockedRunner)

	var (
		class       = gen.UniqueReference()
		plArguments = insolar.MustSerialize([]interface{}{})
	)

	{
		typedChecker := server.PublisherMock.SetTypedChecker(ctx, mc, server)
		typedChecker.VCallResult.ExpectedCount(1)
		typedChecker.VCallRequest.Set(func(pl *payload.VCallRequest) bool {
			pn := server.GetPulse().PulseNumber

			msg := utils.NewRequestWrapper(pn, &payload.VCallResult{
				CallType:        pl.CallType,
				CallFlags:       pl.CallFlags,
				CallAsOf:        pl.CallAsOf,
				Caller:          pl.Caller,
				Callee:          pl.Callee,
				CallOutgoing:    pl.CallOutgoing,
				ReturnArguments: plArguments,
			}).Finalize()

			server.SendMessage(ctx, msg)

			return false
		}).ExpectedCount(1)
	}

	server.Init(ctx)

	var (
		pn        = server.GetPulse().PulseNumber
		isolation = contract.ConstructorIsolation()
	)

	pl := payload.VCallRequest{
		CallType:       payload.CTConstructor,
		CallFlags:      payload.BuildCallFlags(isolation.Interference, isolation.State),
		Caller:         server.GlobalCaller(),
		Callee:         class,
		CallSiteMethod: "New",
		CallOutgoing:   gen.UniqueIDWithPulse(pn),
		Arguments:      plArguments,
	}
	msg := utils.NewRequestWrapper(pn, &pl).Finalize()

	{
		builder := executionevent.NewRPCBuilder(reference.Global{}, reference.Global{})
		outgoing := builder.CallMethod(reference.Global{}, reference.Global{}, "Method", plArguments)

		result := requestresult.New([]byte{}, reference.Global{})
		result.SetActivate(reference.Global{}, reference.Global{}, []byte{})

		executionMock := mockedRunner.AddExecutionMock(calculateOutgoing(pl).String())
		executionMock.AddStart(nil, &executionupdate.ContractExecutionStateUpdate{
			Type:     executionupdate.OutgoingCall,
			Outgoing: outgoing,
		})
		executionMock.AddContinue(nil, &executionupdate.ContractExecutionStateUpdate{
			Type:   executionupdate.Done,
			Result: result,
		})
	}

	server.SendMessage(ctx, msg)

	server.PublisherMock.WaitCount(2, 10*time.Second)

	mc.Finish()
}
```

[Example](https://github.com/insolar/assured-ledger/pull/291/files#diff-54653f38a792f4fd738c028ee9be4b7b) of how to write external library helpers, for now