### PR TITLE
NOISSUE: fix RequestTable.GetList return pointer to copy of RequestList

### DIFF
--- a/ledger-core/virtual/object/request_table.go
+++ b/ledger-core/virtual/object/request_table.go
@@ -13,12 +13,12 @@ import (
 )
 
 type RequestTable struct {
-	lists map[contract.InterferenceFlag]RequestList
+	lists map[contract.InterferenceFlag]*RequestList
 }
 
 func NewRequestTable() RequestTable {
 	var rt RequestTable
-	rt.lists = make(map[contract.InterferenceFlag]RequestList)
+	rt.lists = make(map[contract.InterferenceFlag]*RequestList)
 
 	rt.lists[contract.CallTolerable] = NewRequestList()
 	rt.lists[contract.CallIntolerable] = NewRequestList()
@@ -29,8 +29,7 @@ func (rt *RequestTable) GetList(flag contract.InterferenceFlag) *RequestList {
 	if flag.IsZero() {
 		panic(throw.IllegalValue())
 	}
-	list := rt.lists[flag]
-	return &list
+	return rt.lists[flag]
 }
 
 func (rt *RequestTable) Len() int {
@@ -48,8 +47,8 @@ type RequestList struct {
 	requests      map[reference.Global]isActive
 }
 
-func NewRequestList() RequestList {
-	return RequestList{
+func NewRequestList() *RequestList {
+	return &RequestList{
 		requests: make(map[reference.Global]isActive),
 	}
 }

--- a/ledger-core/virtual/object/request_table_test.go
+++ b/ledger-core/virtual/object/request_table_test.go
@@ -21,10 +21,10 @@ func TestRequestTable(t *testing.T) {
 	rt := NewRequestTable()
 
 	require.Equal(t, 0, len(rt.GetList(contract.CallIntolerable).requests))
-	require.Equal(t, 0, len(rt.GetList(contract.CallIntolerable).requests))
+	require.Equal(t, 0, len(rt.GetList(contract.CallTolerable).requests))
 
 	require.Equal(t, pulse.Number(0), rt.GetList(contract.CallIntolerable).earliestPulse)
-	require.Equal(t, pulse.Number(0), rt.GetList(contract.CallIntolerable).earliestPulse)
+	require.Equal(t, pulse.Number(0), rt.GetList(contract.CallTolerable).earliestPulse)
 
 	pd := pulse.NewFirstPulsarData(10, longbits.Bits256{})
 	currentPulse := pd.PulseNumber
@@ -36,6 +36,8 @@ func TestRequestTable(t *testing.T) {
 	intolerableList.Add(ref)
 
 	require.Equal(t, 1, len(rt.GetList(contract.CallIntolerable).requests))
+	require.Equal(t, 0, len(rt.GetList(contract.CallTolerable).requests))
+	require.Equal(t, currentPulse, rt.GetList(contract.CallIntolerable).EarliestPulse())
 }
 
 func TestRequestList(t *testing.T) {


### PR DESCRIPTION
**- What I did**
Fix RequestTable.GetList return pointer to copy of RequestList

**- How I did it**
RequestTable will save pointers to RequestList and  return it in GetList

**- How to verify it**

**- Description for the changelog**

