### PR TITLE
NOISSUE: fix pgrep+kill workaround for Linux

### DIFF
--- a/ledger-core/Makefile.testing
+++ b/ledger-core/Makefile.testing
@@ -27,7 +27,7 @@ test_func: ## run functest FUNCTEST_COUNT times
 
 .PHONY: test_func_slow
 test_func_slow: # Run functests as long as practical to catch unexpected behavior during pulse change
-	pgrep insolard | xargs kill -9 # dirty hack to terminate all insolard processes
+	( pgrep insolard | xargs kill -9 ) || true # dirty hack to terminate all insolard processes
 	FUNCTEST_COUNT=100 PULSAR_ONESHOT=FALSE PULSAR_PULSETIME=5000 TEST_ARGS='-timeout 1200s -failfast' make test_func
 
 .PNONY: test_func_race


### PR DESCRIPTION
kill + pgrep returns error on Linux if insolard is not running