### PR TITLE
NOISSUE: fix for vcallrequest that goes to antique slot

### DIFF
--- a/ledger-core/network/messagesender/service.go
+++ b/ledger-core/network/messagesender/service.go
@@ -19,8 +19,7 @@ import (
 	"github.com/insolar/assured-ledger/ledger-core/instrumentation/instracer"
 	"github.com/insolar/assured-ledger/ledger-core/pulse"
 	"github.com/insolar/assured-ledger/ledger-core/reference"
-
-	errors "github.com/insolar/assured-ledger/ledger-core/vanilla/throw"
+	"github.com/insolar/assured-ledger/ledger-core/vanilla/throw"
 )
 
 type options struct {
@@ -71,12 +70,12 @@ func (dm *DefaultService) Close() error {
 func (dm *DefaultService) SendRole(ctx context.Context, msg payload.Marshaler, role node.DynamicRole, object reference.Global, pn pulse.Number, opts ...SendOption) error {
 	waterMillMsg, err := payload.NewMessage(msg.(payload.Payload))
 	if err != nil {
-		return errors.W(err, "Can't create watermill message")
+		return throw.W(err, "Can't create watermill message")
 	}
 
 	nodes, err := dm.affinity.QueryRole(ctx, role, object.GetLocal(), pn)
 	if err != nil {
-		return errors.W(err, "failed to calculate role")
+		return throw.W(err, "failed to calculate role")
 	}
 
 	return dm.sendTarget(ctx, waterMillMsg, nodes[0], pn)
@@ -85,7 +84,7 @@ func (dm *DefaultService) SendRole(ctx context.Context, msg payload.Marshaler, r
 func (dm *DefaultService) SendTarget(ctx context.Context, msg payload.Marshaler, target reference.Global, opts ...SendOption) error {
 	waterMillMsg, err := payload.NewMessage(msg.(payload.Payload))
 	if err != nil {
-		return errors.W(err, "Can't create watermill message")
+		return throw.W(err, "Can't create watermill message")
 	}
 
 	var pn pulse.Number
@@ -96,7 +95,7 @@ func (dm *DefaultService) SendTarget(ctx context.Context, msg payload.Marshaler,
 		// It's possible, that we try to fetch something in PM.Set()
 		// In those cases, when we in the start of the system, we don't have any pulses
 		// but this is not the error
-		inslogger.FromContext(ctx).Warn(errors.W(err, "failed to fetch pulse"))
+		inslogger.FromContext(ctx).Warn(throw.W(err, "failed to fetch pulse"))
 	}
 	return dm.sendTarget(ctx, waterMillMsg, target, pn)
 }
@@ -120,14 +119,18 @@ func (dm *DefaultService) sendTarget(
 	msg.SetContext(ctx)
 	_, msg, err = dm.wrapMeta(msg, target, payload.MessageHash{}, pulse)
 	if err != nil {
-		inslogger.FromContext(ctx).Error(errors.W(err, "failed to send message"))
-		return errors.W(err, "can't wrap meta message")
+		inslogger.FromContext(ctx).Error(throw.W(err, "failed to send message"))
+		return throw.W(err, "can't wrap meta message")
 	}
 
 	logger.Debugf("sending message")
 	err = dm.pub.Publish(TopicOutgoing, msg)
 	if err != nil {
-		return errors.Wrapf(err, "can't publish message to %s topic", TopicOutgoing)
+		return throw.W(err, "can't publish message", struct {
+			Topic string
+		}{
+			Topic: TopicOutgoing,
+		})
 	}
 
 	return nil
@@ -155,7 +158,7 @@ func (dm *DefaultService) wrapMeta(
 
 	buf, err := payloadMeta.Marshal()
 	if err != nil {
-		return payload.Meta{}, nil, errors.W(err, "wrapMeta. failed to wrap message")
+		return payload.Meta{}, nil, throw.W(err, "wrapMeta. failed to wrap message")
 	}
 	msg.Payload = buf
 	msg.Metadata.Set(defaults.Receiver, receiver.String())

--- a/ledger-core/virtual/handlers/vcallrequest.go
+++ b/ledger-core/virtual/handlers/vcallrequest.go
@@ -8,6 +8,7 @@
 package handlers
 
 import (
+	"github.com/insolar/assured-ledger/ledger-core/conveyor"
 	"github.com/insolar/assured-ledger/ledger-core/conveyor/smachine"
 	"github.com/insolar/assured-ledger/ledger-core/insolar/payload"
 	"github.com/insolar/assured-ledger/ledger-core/vanilla/injector"
@@ -18,6 +19,8 @@ type SMVCallRequest struct {
 	// input arguments
 	Meta    *payload.Meta
 	Payload *payload.VCallRequest
+
+	pulseSlot *conveyor.PulseSlot
 }
 
 /* -------- Declaration ------------- */
@@ -28,7 +31,10 @@ type dSMVCallRequest struct {
 	smachine.StateMachineDeclTemplate
 }
 
-func (*dSMVCallRequest) InjectDependencies(_ smachine.StateMachine, _ smachine.SlotLink, _ *injector.DependencyInjector) {
+func (*dSMVCallRequest) InjectDependencies(sm smachine.StateMachine, _ smachine.SlotLink, injector *injector.DependencyInjector) {
+	s := sm.(*SMVCallRequest)
+
+	injector.MustInject(&s.pulseSlot)
 }
 
 func (*dSMVCallRequest) GetInitStateFor(sm smachine.StateMachine) smachine.InitFunc {


### PR DESCRIPTION
**- What I did**

- fix for vcallrequest that goes to antique slot (replacing SM had no dependencies)
- some more throw usage instead of errors in messagesender
- removed wrapf from jet affinityHelper