### PR TITLE
NOISSUE: execute fixes: deduplication, migration leak, wrong descriptor

### DIFF
--- a/ledger-core/application/testwalletapi/statemachine/statemachine.go
+++ b/ledger-core/application/testwalletapi/statemachine/statemachine.go
@@ -112,7 +112,7 @@ func (s *SMTestAPICall) stepSendRequest(ctx smachine.ExecutionContext) smachine.
 	}
 
 	s.messageSender.PrepareAsync(ctx, func(goCtx context.Context, svc messagesender.Service) smachine.AsyncResultFunc {
-		err := svc.SendRole(goCtx, &payloadData, node.DynamicRoleVirtualExecutor, obj, s.pulseSlot.PulseData().PulseNumber)
+		err := svc.SendRole(goCtx, &payloadData, node.DynamicRoleVirtualExecutor, obj, s.pulseSlot.CurrentPulseNumber())
 		s.messageAlreadySent = true
 		return func(ctx smachine.AsyncResultContext) {
 			if err != nil {

--- a/ledger-core/virtual/execute/execute.go
+++ b/ledger-core/virtual/execute/execute.go
@@ -526,7 +526,7 @@ func (s *SMExecute) stepSendOutgoing(ctx smachine.ExecutionContext) smachine.Sta
 	}
 
 	s.messageSender.PrepareAsync(ctx, func(goCtx context.Context, svc messagesender.Service) smachine.AsyncResultFunc {
-		err := svc.SendRole(goCtx, s.outgoing, node.DynamicRoleVirtualExecutor, s.outgoingObject, s.pulseSlot.PulseData().PulseNumber)
+		err := svc.SendRole(goCtx, s.outgoing, node.DynamicRoleVirtualExecutor, s.outgoingObject, s.pulseSlot.CurrentPulseNumber())
 		return func(ctx smachine.AsyncResultContext) {
 			if err != nil {
 				ctx.Log().Error("failed to send message", err)

--- a/ledger-core/virtual/execute/execute.plantuml
+++ b/ledger-core/virtual/execute/execute.plantuml
@@ -2,151 +2,131 @@
 state "Init" as T01_S002
 T01_S002 : SMExecute
 [*] --> T01_S002
-T01_S002 --> T01_S003 : Migrate: s.migrationDefault
-state "migrateDuringExecution" as T01_S011
-T01_S011 : SMExecute
-T01_S011 --> T01_S012
-state "migrateDuringSendOutgoing" as T01_S022
-T01_S022 : SMExecute
-T01_S022 --> T01_S020
+T01_S002 --> T01_S003
+state "migrateDuringExecution" as T01_S010
+T01_S010 : SMExecute
+T01_S010 --[dotted]> T01_S010
+T01_S010 --> T01_S011
+state "migrateDuringSendOutgoing" as T01_S020
+T01_S020 : SMExecute
+T01_S020 --[dotted]> T01_S020
+T01_S020 --> T01_S019
 state "migrationDefault" as T01_S001
 T01_S001 : SMExecute
-T01_S001 --> [*]
-state "s.messageSender" as T01_S021 <<sdlreceive>>
-T01_S021 : DUPLICATE
-state "s.runner" as T01_S007 <<sdlreceive>>
-T01_S007 : DUPLICATE
+T01_S001 --[dotted]> T01_S001
+T01_S001 -->[*]
 state "stepCheckRequest" as T01_S003
 T01_S003 : SMExecute
 T01_S003 --[dotted]> T01_S001
 T01_S003 --> T01_S004
-state "stepDeduplicate" as T01_S009
-T01_S009 : SMExecute
-T01_S009 --[dotted]> T01_S001
-T01_S009 --[dashed]> T01_S009 : [smachine.NotPassed]\n[(...).AcquireForThisStep().IsNotPassed()]...\nWaitShared, Sleep
-T01_S009 --[dashed]> [*] : [isDuplicate]\nError
-T01_S009 --> T01_S010
-state "stepExecuteAborted" as T01_S018
-T01_S018 : SMExecute
-T01_S018 --[dotted]> T01_S011
-T01_S018 --[dotted]> T01_S022
-T01_S018 --[dashed]> [*] : Error
-state "stepExecuteContinue" as T01_S023
-T01_S023 : SMExecute
-T01_S023 --[dotted]> T01_S011
-T01_S023 --[dotted]> T01_S022
-state T01_U001 <<fork>>
-T01_S023 --> T01_U001
-T01_U001 --> T01_S007 : PrepareExecutionContinue(ctx)
-T01_U001 --[dashed]> T01_S016
-state "stepExecuteDecideNextStep" as T01_S017
+state "stepDeduplicate" as T01_S008
+T01_S008 : SMExecute
+T01_S008 --[dotted]> T01_S001
+T01_S008 -> T01_S008 : [smachine.NotPassed]\n[(...).AcquireForThisStep().IsNotPassed()]...\nWaitShared, Sleep
+T01_S008 -->[*] : [isDuplicate]\nError
+T01_S008 --> T01_S009
+state "stepExecuteAborted" as T01_S017
 T01_S017 : SMExecute
-T01_S017 --[dotted]> T01_S011
-T01_S017 --[dotted]> T01_S022
-T01_S017 --> T01_S024 : [executionupdate.Done]
-T01_S017 --> T01_S018 : [executionupdate.Aborted]
-T01_S017 --> T01_S019 : [executionupdate.OutgoingCall]
-state "stepExecuteOutgoing" as T01_S019
-T01_S019 : SMExecute
-T01_S019 --[dotted]> T01_S011
-T01_S019 --[dotted]> T01_S022
-T01_S019 --> T01_S020 : [s.outgoing!=nil]
-T01_S019 --> T01_S023
-state "stepExecuteStart" as T01_S015
-T01_S015 : SMExecute
-T01_S015 --[dotted]> T01_S011
-state T01_U002 <<fork>>
-T01_S015 --> T01_U002
-T01_U002 --> T01_S007 : PrepareExecutionStart(ctx)
-T01_U002 --[dashed]> T01_S016
-state "stepFinishRequest" as T01_S027
-T01_S027 : SMExecute
-T01_S027 --[dotted]> T01_S011
-T01_S027 --[dotted]> T01_S022
-T01_S027 --> T01_S025 : [s.migrationHappened]
-T01_S027 --[dashed]> T01_S027 : [smachine.NotPassed]\nWaitShared
-T01_S027 --> [*]
-state "stepGetDelegationToken" as T01_S012
-T01_S012 : SMExecute
-T01_S012 --[dotted]> T01_S011
-T01_S012 --> T01_S013 : CallSubroutine
-state "stepGetDelegationToken.2" as T01_S014
+T01_S017 --[dotted]> T01_S010
+T01_S017 -->[*] : Error
+state "stepExecuteContinue" as T01_S021
+T01_S021 : SMExecute
+T01_S021 --[dotted]> T01_S010
+T01_S021 --[dotted]> T01_S020
+T01_S021 --> T01_S015 : PrepareExecutionContinue.DelayedStart
+state "stepExecuteDecideNextStep" as T01_S016
+T01_S016 : SMExecute
+T01_S016 --[dotted]> T01_S010
+T01_S016 --> T01_S022 : [executionupdate.Done]\n
+T01_S016 --> T01_S017 : [executionupdate.Aborted]\n
+T01_S016 --> T01_S018 : [executionupdate.OutgoingCall]\n
+state "stepExecuteOutgoing" as T01_S018
+T01_S018 : SMExecute
+T01_S018 --[dotted]> T01_S010
+T01_S018 --> T01_S019 : [s.outgoing!=nil]\n
+T01_S018 --> T01_S021
+state "stepExecuteStart" as T01_S014
 T01_S014 : SMExecute
-T01_S014 --[dotted]> T01_S011
-state "DYNAMIC stepAfterTokenGet" as T01_U003
-T01_U003 : SMExecute
-T01_U003 : UNKNOWN 
-T01_S014 --> T01_U003
-state "stepGetDelegationToken.subroutineSM.1" as T01_S013 <<sdlreceive>>
-T01_S013 --> T01_S014 : Migrate: <nil>
+T01_S014 --[dotted]> T01_S010
+T01_S014 --> T01_S015 : PrepareExecutionStart.DelayedStart
+state "stepFinishRequest" as T01_S025
+T01_S025 : SMExecute
+T01_S025 --[dotted]> T01_S010
+T01_S025 --> T01_S023 : [s.migrationHappened]\n
+T01_S025 -> T01_S025 : [smachine.NotPassed]\nWaitShared
+T01_S025 -->[*]
+state "stepGetDelegationToken" as T01_S011
+T01_S011 : SMExecute
+T01_S011 --[dotted]> T01_S010
+T01_S011 --> T01_S012 : CallSubroutine
+state "stepGetDelegationToken.2" as T01_S013
+T01_S013 : SMExecute
+T01_S013 --[dotted]> T01_S010
+state "DYNAMIC stepAfterTokenGet" as T01_U001
+T01_U001 : SMExecute
+T01_U001 : UNKNOWN 
+T01_S013 --> T01_U001
+state "stepGetDelegationToken.subroutineSM.1" as T01_S012 <<sdlreceive>>
+T01_S012 --[dotted]> T01_S010
+T01_S012 --> T01_S013
 state "stepGetObject" as T01_S004
 T01_S004 : SMExecute
 T01_S004 --[dotted]> T01_S001
-T01_S004 --[dashed]> T01_S004 : [smachine.NotPassed]\nWaitShared
+T01_S004 -> T01_S004 : [smachine.NotPassed]\nWaitShared
 T01_S004 --> T01_S005
 state "stepIsolationNegotiation" as T01_S006
 T01_S006 : SMExecute
 T01_S006 --[dotted]> T01_S001
-state T01_U004 <<fork>>
-T01_S006 --> T01_U004 : [s.methodIsolation.IsZero()]
-T01_U004 --> T01_S007 : PrepareExecutionClassify(ctx)
-T01_U004 --[dashed]> T01_S006 : Sleep
-T01_S006 --[dashed]> [*] : [err!=nil]\nError
-T01_S006 --> T01_S008
-state "stepSaveNewObject" as T01_S024
+T01_S006 -> T01_S006 : [s.methodIsolation.IsZero()]\nDelayedStart.Sleep
+T01_S006 -->[*] : [err!=nil]\nError
+T01_S006 --> T01_S007
+state "stepSaveNewObject" as T01_S022
+T01_S022 : SMExecute
+T01_S022 --[dotted]> T01_S010
+T01_S022 --> T01_S024 : [(...).migrationHappened||s.newObjectDescriptor==nil]\n
+T01_S022 -> T01_S022 : [smachine.NotPassed]\nWaitShared
+T01_S022 --> T01_S024
+state "stepSendCallResult" as T01_S024
 T01_S024 : SMExecute
-T01_S024 --[dotted]> T01_S011
-T01_S024 --[dotted]> T01_S022
-T01_S024 --> T01_S026 : [(...).migrationHappened||s.newObjectDescriptor==nil]
-T01_S024 --[dashed]> T01_S024 : [smachine.NotPassed]\nWaitShared
-T01_S024 --> T01_S026
-state "stepSendCallResult" as T01_S026
-T01_S026 : SMExecute
-T01_S026 --[dotted]> T01_S011
-T01_S026 --[dotted]> T01_S022
-T01_S026 --> T01_S021 : PrepareAsync(ctx).WithoutAutoWakeUp()
-T01_S026 --> T01_S027
-state "stepSendDelegatedRequestFinished" as T01_S025
-T01_S025 : SMExecute
-T01_S025 --[dotted]> T01_S011
-T01_S025 --[dotted]> T01_S022
-T01_S025 --> T01_S021 : PrepareAsync(ctx).WithoutAutoWakeUp()
-T01_S025 --> [*]
-state "stepSendOutgoing" as T01_S020
-T01_S020 : SMExecute
-T01_S020 --[dotted]> T01_S011
-T01_S020 --[dotted]> T01_S022
-T01_S020 --[dashed]> [*] : [!(...).PublishGlobalAliasAndBargeIn()]\nError
-T01_S020 --> T01_S021 : PrepareAsync(ctx).WithoutAutoWakeUp()
-T01_S020 --[dashed]> T01_S023 : Migrate: s.migrateDuringSendOutgoing\nSleep
-state "stepStartRequestProcessing" as T01_S010
-T01_S010 : SMExecute
-T01_S010 --[dotted]> T01_S001
-T01_S010 --[dashed]> T01_S010 : [smachine.NotPassed]\nWaitShared
-T01_S010 --> [*] : [isDuplicate]
-T01_S010 --> T01_S015 : Migrate: s.migrateDuringExecution
-state "stepTakeLock" as T01_S008
-T01_S008 : SMExecute
-T01_S008 --[dotted]> T01_S001
-T01_S008 --[dashed]> T01_S008 : [ctx.Acquire().IsNotPassed()]\nSleep
-T01_S008 --> T01_S009 : [(...).GetRepeatedCall()==payload.RepeatedCall]
-T01_S008 --> T01_S010
-state "stepWaitExecutionResult" as T01_S016
-T01_S016 : SMExecute
-T01_S016 --[dotted]> T01_S011
-T01_S016 --[dotted]> T01_S022
-T01_S016 --[dashed]> T01_S016 : [s.executionNewState==nil]\nSleep
-T01_S016 --> T01_S017
+T01_S024 --[dotted]> T01_S010
+T01_S024 --> T01_S025
+state "stepSendDelegatedRequestFinished" as T01_S023
+T01_S023 : SMExecute
+T01_S023 --[dotted]> T01_S010
+T01_S023 -->[*]
+state "stepSendOutgoing" as T01_S019
+T01_S019 : SMExecute
+T01_S019 --[dotted]> T01_S010
+T01_S019 --[dotted]> T01_S020
+T01_S019 -->[*] : [!(...).PublishGlobalAliasAndBargeIn()]\nError
+T01_S019 --> T01_S021 : Sleep
+state "stepStartRequestProcessing" as T01_S009
+T01_S009 : SMExecute
+T01_S009 --[dotted]> T01_S001
+T01_S009 -> T01_S009 : [smachine.NotPassed]\nWaitShared
+T01_S009 -->[*] : [isDuplicate]\n
+T01_S009 --> T01_S014
+state "stepTakeLock" as T01_S007
+T01_S007 : SMExecute
+T01_S007 --[dotted]> T01_S001
+T01_S007 -> T01_S007 : [ctx.Acquire().IsNotPassed()]\nSleep
+T01_S007 --> T01_S008 : [(...).GetRepeatedCall()==payload.RepeatedCall]\n
+T01_S007 --> T01_S009
+state "stepWaitExecutionResult" as T01_S015
+T01_S015 : SMExecute
+T01_S015 --[dotted]> T01_S010
+T01_S015 -> T01_S015 : [s.executionNewState==nil]\nSleep
+T01_S015 --> T01_S016
 state "stepWaitObjectReady" as T01_S005
 T01_S005 : SMExecute
 T01_S005 --[dotted]> T01_S001
-T01_S005 --[dashed]> T01_S005 : [smachine.NotPassed]\n[(...).AcquireForThisStep().IsNotPassed()]...\nWaitShared, Sleep
+T01_S005 -> T01_S005 : [smachine.NotPassed]\n[(...).AcquireForThisStep().IsNotPassed()]...\nWaitShared, Sleep
 T01_S005 --> T01_S006
 state "GetInitStateFor" as T00_S001
 T00_S001 : dSMExecute
 [*] --> T00_S001
-state "s.Init" as T00_U005
-T00_U005 : dSMExecute
-T00_U005 : UNKNOWN 
-T00_S001 --> T00_U005
+state "s.Init" as T00_U002
+T00_U002 : dSMExecute
+T00_U002 : UNKNOWN 
+T00_S001 --> T00_U002
 @enduml

--- a/ledger-core/virtual/execute/execute.plantuml
+++ b/ledger-core/virtual/execute/execute.plantuml
@@ -19,12 +19,12 @@ state "stepCheckRequest" as T01_S003
 T01_S003 : SMExecute
 T01_S003 --[dotted]> T01_S001
 T01_S003 --> T01_S004
-state "stepDeduplicate" as T01_S008
-T01_S008 : SMExecute
-T01_S008 --[dotted]> T01_S001
-T01_S008 -> T01_S008 : [smachine.NotPassed]\n[(...).AcquireForThisStep().IsNotPassed()]...\nWaitShared, Sleep
-T01_S008 -->[*] : [isDuplicate]\nError
-T01_S008 --> T01_S009
+state "stepDeduplicate" as T01_S007
+T01_S007 : SMExecute
+T01_S007 --[dotted]> T01_S001
+T01_S007 -> T01_S007 : [smachine.NotPassed]\n[(...).AcquireForThisStep().IsNotPassed()]...\nWaitShared, Sleep
+T01_S007 -->[*] : [isDuplicate]\n
+T01_S007 --> T01_S008
 state "stepExecuteAborted" as T01_S017
 T01_S017 : SMExecute
 T01_S017 --[dotted]> T01_S010
@@ -79,7 +79,8 @@ T01_S006 : SMExecute
 T01_S006 --[dotted]> T01_S001
 T01_S006 -> T01_S006 : [s.methodIsolation.IsZero()]\nDelayedStart.Sleep
 T01_S006 -->[*] : [err!=nil]\nError
-T01_S006 --> T01_S007
+T01_S006 --> T01_S007 : [...<(...).pulseSlot.CurrentPulseNumber()]\n
+T01_S006 --> T01_S008
 state "stepSaveNewObject" as T01_S022
 T01_S022 : SMExecute
 T01_S022 --[dotted]> T01_S010
@@ -106,12 +107,11 @@ T01_S009 --[dotted]> T01_S001
 T01_S009 -> T01_S009 : [smachine.NotPassed]\nWaitShared
 T01_S009 -->[*] : [isDuplicate]\n
 T01_S009 --> T01_S014
-state "stepTakeLock" as T01_S007
-T01_S007 : SMExecute
-T01_S007 --[dotted]> T01_S001
-T01_S007 -> T01_S007 : [ctx.Acquire().IsNotPassed()]\nSleep
-T01_S007 --> T01_S008 : [(...).GetRepeatedCall()==payload.RepeatedCall]\n
-T01_S007 --> T01_S009
+state "stepTakeLock" as T01_S008
+T01_S008 : SMExecute
+T01_S008 --[dotted]> T01_S001
+T01_S008 -> T01_S008 : [ctx.Acquire().IsNotPassed()]\nSleep
+T01_S008 --> T01_S009
 state "stepWaitExecutionResult" as T01_S015
 T01_S015 : SMExecute
 T01_S015 --[dotted]> T01_S010

--- a/ledger-core/virtual/execute/execute.plantuml
+++ b/ledger-core/virtual/execute/execute.plantuml
@@ -2,131 +2,140 @@
 state "Init" as T01_S002
 T01_S002 : SMExecute
 [*] --> T01_S002
-T01_S002 --> T01_S003
-state "migrateDuringExecution" as T01_S010
-T01_S010 : SMExecute
-T01_S010 --[dotted]> T01_S010
-T01_S010 --> T01_S011
-state "migrateDuringSendOutgoing" as T01_S020
-T01_S020 : SMExecute
-T01_S020 --[dotted]> T01_S020
-T01_S020 --> T01_S019
+T01_S002 --> T01_S003 : Migrate: s.migrationDefault
+state "migrateDuringExecution" as T01_S011
+T01_S011 : SMExecute
+T01_S011 --[dashed]> [*] : [...&&(...).delegationTokenSpec.IsZero()]\nError
+T01_S011 --> T01_S012
 state "migrationDefault" as T01_S001
 T01_S001 : SMExecute
-T01_S001 --[dotted]> T01_S001
-T01_S001 -->[*]
+T01_S001 --> [*]
+state "s.messageSender" as T01_S021 <<sdlreceive>>
+T01_S021 : DUPLICATE
+state "s.runner" as T01_S007 <<sdlreceive>>
+T01_S007 : DUPLICATE
 state "stepCheckRequest" as T01_S003
 T01_S003 : SMExecute
 T01_S003 --[dotted]> T01_S001
 T01_S003 --> T01_S004
-state "stepDeduplicate" as T01_S007
-T01_S007 : SMExecute
-T01_S007 --[dotted]> T01_S001
-T01_S007 -> T01_S007 : [smachine.NotPassed]\n[(...).AcquireForThisStep().IsNotPassed()]...\nWaitShared, Sleep
-T01_S007 -->[*] : [isDuplicate]\n
-T01_S007 --> T01_S008
-state "stepExecuteAborted" as T01_S017
-T01_S017 : SMExecute
-T01_S017 --[dotted]> T01_S010
-T01_S017 -->[*] : Error
-state "stepExecuteContinue" as T01_S021
-T01_S021 : SMExecute
-T01_S021 --[dotted]> T01_S010
-T01_S021 --[dotted]> T01_S020
-T01_S021 --> T01_S015 : PrepareExecutionContinue.DelayedStart
-state "stepExecuteDecideNextStep" as T01_S016
-T01_S016 : SMExecute
-T01_S016 --[dotted]> T01_S010
-T01_S016 --> T01_S022 : [executionupdate.Done]\n
-T01_S016 --> T01_S017 : [executionupdate.Aborted]\n
-T01_S016 --> T01_S018 : [executionupdate.OutgoingCall]\n
-state "stepExecuteOutgoing" as T01_S018
+state "stepDeduplicate" as T01_S008
+T01_S008 : SMExecute
+T01_S008 --[dotted]> T01_S001
+T01_S008 --[dashed]> T01_S008 : [smachine.NotPassed]\n[(...).AcquireForThisStep().IsNotPassed()]...\nWaitShared, Sleep
+T01_S008 --> [*] : [isDuplicate]
+T01_S008 --> T01_S009
+state "stepExecuteAborted" as T01_S018
 T01_S018 : SMExecute
-T01_S018 --[dotted]> T01_S010
-T01_S018 --> T01_S019 : [s.outgoing!=nil]\n
-T01_S018 --> T01_S021
-state "stepExecuteStart" as T01_S014
+T01_S018 --[dotted]> T01_S011
+T01_S018 --[dashed]> [*] : Error
+state "stepExecuteContinue" as T01_S022
+T01_S022 : SMExecute
+T01_S022 --[dotted]> T01_S011
+state T01_U001 <<fork>>
+T01_S022 --> T01_U001
+T01_U001 --> T01_S007 : Migrate: s
+T01_U001 --[dashed]> T01_S016 : migrateDuringExecution\nPrepareExecutionContinue(ctx).
+state "stepExecuteDecideNextStep" as T01_S017
+T01_S017 : SMExecute
+T01_S017 --[dotted]> T01_S011
+T01_S017 --> T01_S023 : [executionupdate.Done]
+T01_S017 --> T01_S018 : [executionupdate.Aborted]
+T01_S017 --> T01_S019 : [executionupdate.OutgoingCall]
+state "stepExecuteOutgoing" as T01_S019
+T01_S019 : SMExecute
+T01_S019 --[dotted]> T01_S011
+T01_S019 --> T01_S020 : [s.outgoing!=nil]
+T01_S019 --> T01_S022
+state "stepExecuteStart" as T01_S015
+T01_S015 : SMExecute
+T01_S015 --[dotted]> T01_S011
+state T01_U002 <<fork>>
+T01_S015 --> T01_U002
+T01_U002 --> T01_S007 : PrepareExecutionStart(ctx)
+T01_U002 --[dashed]> T01_S016
+state "stepFinishRequest" as T01_S026
+T01_S026 : SMExecute
+T01_S026 --[dotted]> T01_S011
+T01_S026 --> T01_S024 : [s.migrationHappened]
+T01_S026 --[dashed]> T01_S026 : [smachine.NotPassed]\nWaitShared
+T01_S026 --> [*]
+state "stepGetDelegationToken" as T01_S012
+T01_S012 : SMExecute
+T01_S012 --[dotted]> T01_S011
+T01_S012 --> T01_S013 : CallSubroutine
+state "stepGetDelegationToken.2" as T01_S014
 T01_S014 : SMExecute
-T01_S014 --[dotted]> T01_S010
-T01_S014 --> T01_S015 : PrepareExecutionStart.DelayedStart
-state "stepFinishRequest" as T01_S025
-T01_S025 : SMExecute
-T01_S025 --[dotted]> T01_S010
-T01_S025 --> T01_S023 : [s.migrationHappened]\n
-T01_S025 -> T01_S025 : [smachine.NotPassed]\nWaitShared
-T01_S025 -->[*]
-state "stepGetDelegationToken" as T01_S011
-T01_S011 : SMExecute
-T01_S011 --[dotted]> T01_S010
-T01_S011 --> T01_S012 : CallSubroutine
-state "stepGetDelegationToken.2" as T01_S013
-T01_S013 : SMExecute
-T01_S013 --[dotted]> T01_S010
-state "DYNAMIC stepAfterTokenGet" as T01_U001
-T01_U001 : SMExecute
-T01_U001 : UNKNOWN 
-T01_S013 --> T01_U001
-state "stepGetDelegationToken.subroutineSM.1" as T01_S012 <<sdlreceive>>
-T01_S012 --[dotted]> T01_S010
-T01_S012 --> T01_S013
+T01_S014 --[dotted]> T01_S011
+T01_S014 --> T01_S020 : [s.outgoingWasSent]
+state "DYNAMIC stepAfterTokenGet" as T01_U003
+T01_U003 : SMExecute
+T01_U003 : UNKNOWN 
+T01_S014 --> T01_U003
+state "stepGetDelegationToken.subroutineSM.1" as T01_S013 <<sdlreceive>>
+T01_S013 --> T01_S014 : Migrate: <nil>
 state "stepGetObject" as T01_S004
 T01_S004 : SMExecute
 T01_S004 --[dotted]> T01_S001
-T01_S004 -> T01_S004 : [smachine.NotPassed]\nWaitShared
+T01_S004 --[dashed]> T01_S004 : [smachine.NotPassed]\nWaitShared
 T01_S004 --> T01_S005
 state "stepIsolationNegotiation" as T01_S006
 T01_S006 : SMExecute
 T01_S006 --[dotted]> T01_S001
-T01_S006 -> T01_S006 : [s.methodIsolation.IsZero()]\nDelayedStart.Sleep
-T01_S006 -->[*] : [err!=nil]\nError
-T01_S006 --> T01_S007 : [...<(...).pulseSlot.CurrentPulseNumber()]\n
-T01_S006 --> T01_S008
-state "stepSaveNewObject" as T01_S022
-T01_S022 : SMExecute
-T01_S022 --[dotted]> T01_S010
-T01_S022 --> T01_S024 : [(...).migrationHappened||s.newObjectDescriptor==nil]\n
-T01_S022 -> T01_S022 : [smachine.NotPassed]\nWaitShared
-T01_S022 --> T01_S024
-state "stepSendCallResult" as T01_S024
-T01_S024 : SMExecute
-T01_S024 --[dotted]> T01_S010
-T01_S024 --> T01_S025
-state "stepSendDelegatedRequestFinished" as T01_S023
+state T01_U004 <<fork>>
+T01_S006 --> T01_U004 : [s.methodIsolation.IsZero()]
+T01_U004 --> T01_S007 : PrepareExecutionClassify(ctx)
+T01_U004 --[dashed]> T01_S006 : Sleep
+T01_S006 --[dashed]> [*] : [err!=nil]\nError
+T01_S006 --> T01_S008 : [...<(...).pulseSlot.CurrentPulseNumber()]
+T01_S006 --> T01_S009
+state "stepSaveNewObject" as T01_S023
 T01_S023 : SMExecute
-T01_S023 --[dotted]> T01_S010
-T01_S023 -->[*]
-state "stepSendOutgoing" as T01_S019
-T01_S019 : SMExecute
-T01_S019 --[dotted]> T01_S010
-T01_S019 --[dotted]> T01_S020
-T01_S019 -->[*] : [!(...).PublishGlobalAliasAndBargeIn()]\nError
-T01_S019 --> T01_S021 : Sleep
-state "stepStartRequestProcessing" as T01_S009
+T01_S023 --[dotted]> T01_S011
+T01_S023 --> T01_S025 : [(...).migrationHappened||s.newObjectDescriptor==nil]
+T01_S023 --[dashed]> T01_S023 : [smachine.NotPassed]\nWaitShared
+T01_S023 --> T01_S025
+state "stepSendCallResult" as T01_S025
+T01_S025 : SMExecute
+T01_S025 --[dotted]> T01_S011
+T01_S025 --> T01_S021 : PrepareAsync(ctx).WithoutAutoWakeUp()
+T01_S025 --> T01_S026
+state "stepSendDelegatedRequestFinished" as T01_S024
+T01_S024 : SMExecute
+T01_S024 --[dotted]> T01_S011
+T01_S024 --> T01_S021 : PrepareAsync(ctx).WithoutAutoWakeUp()
+T01_S024 --> [*]
+state "stepSendOutgoing" as T01_S020
+T01_S020 : SMExecute
+T01_S020 --[dotted]> T01_S011
+T01_S020 --[dashed]> [*] : [!(...).PublishGlobalAliasAndBargeIn()]\nError
+T01_S020 --> T01_S021 : PrepareAsync(ctx).WithoutAutoWakeUp()
+T01_S020 --[dashed]> T01_S022 : Sleep
+state "stepStartRequestProcessing" as T01_S010
+T01_S010 : SMExecute
+T01_S010 --[dotted]> T01_S001
+T01_S010 --[dashed]> T01_S010 : [smachine.NotPassed]\nWaitShared
+T01_S010 --> [*] : [isDuplicate]
+T01_S010 --> T01_S015 : Migrate: s.migrateDuringExecution
+state "stepTakeLock" as T01_S009
 T01_S009 : SMExecute
 T01_S009 --[dotted]> T01_S001
-T01_S009 -> T01_S009 : [smachine.NotPassed]\nWaitShared
-T01_S009 -->[*] : [isDuplicate]\n
-T01_S009 --> T01_S014
-state "stepTakeLock" as T01_S008
-T01_S008 : SMExecute
-T01_S008 --[dotted]> T01_S001
-T01_S008 -> T01_S008 : [ctx.Acquire().IsNotPassed()]\nSleep
-T01_S008 --> T01_S009
-state "stepWaitExecutionResult" as T01_S015
-T01_S015 : SMExecute
-T01_S015 --[dotted]> T01_S010
-T01_S015 -> T01_S015 : [s.executionNewState==nil]\nSleep
-T01_S015 --> T01_S016
+T01_S009 --[dashed]> T01_S009 : [ctx.Acquire().IsNotPassed()]\nSleep
+T01_S009 --> T01_S010
+state "stepWaitExecutionResult" as T01_S016
+T01_S016 : SMExecute
+T01_S016 --[dotted]> T01_S011
+T01_S016 --[dashed]> T01_S016 : [s.executionNewState==nil]\nSleep
+T01_S016 --> T01_S017
 state "stepWaitObjectReady" as T01_S005
 T01_S005 : SMExecute
 T01_S005 --[dotted]> T01_S001
-T01_S005 -> T01_S005 : [smachine.NotPassed]\n[(...).AcquireForThisStep().IsNotPassed()]...\nWaitShared, Sleep
+T01_S005 --[dashed]> T01_S005 : [smachine.NotPassed]\n[(...).AcquireForThisStep().IsNotPassed()]...\nWaitShared, Sleep
 T01_S005 --> T01_S006
 state "GetInitStateFor" as T00_S001
 T00_S001 : dSMExecute
 [*] --> T00_S001
-state "s.Init" as T00_U002
-T00_U002 : dSMExecute
-T00_U002 : UNKNOWN 
-T00_S001 --> T00_U002
+state "s.Init" as T00_U005
+T00_U005 : dSMExecute
+T00_U005 : UNKNOWN 
+T00_S001 --> T00_U005
 @enduml

--- a/ledger-core/virtual/execute/execute_test.go
+++ b/ledger-core/virtual/execute/execute_test.go
@@ -205,7 +205,8 @@ func TestSMExecute_Deduplication(t *testing.T) {
 
 		execCtx := smachine.NewExecutionContextMock(mc).
 			UseSharedMock.Set(shareddata.CallSharedDataAccessor).
-			ErrorMock.Return(smachine.StateUpdate{})
+			LogMock.Return(smachine.Logger{}).
+			StopMock.Return(smachine.StateUpdate{})
 
 		smExecute.stepDeduplicate(execCtx)
 	}
@@ -232,7 +233,7 @@ func TestSMExecute_Deduplication(t *testing.T) {
 		execCtx := smachine.NewExecutionContextMock(mc).
 			UseSharedMock.Set(shareddata.CallSharedDataAccessor).
 			AcquireForThisStepMock.Return(true).
-			JumpMock.Set(testutils.AssertJumpStep(t, smExecute.stepStartRequestProcessing))
+			JumpMock.Set(testutils.AssertJumpStep(t, smExecute.stepTakeLock))
 
 		smExecute.stepDeduplicate(execCtx)
 	}
@@ -240,16 +241,17 @@ func TestSMExecute_Deduplication(t *testing.T) {
 	mc.Finish()
 }
 
-func TestSMExecute_StepTakeLockGoesToDeduplicationForRequestWithRepeatedCallFlag(t *testing.T) {
+func TestSMExecute_DeduplicationForOldRequest(t *testing.T) {
 	var (
 		ctx = inslogger.TestContext(t)
 		mc  = minimock.NewController(t)
 
-		pd              = pulse.NewFirstPulsarData(10, longbits.Bits256{})
+		oldPd           = pulse.NewFirstPulsarData(10, longbits.Bits256{})
+		pd              = pulse.NewPulsarData(oldPd.NextPulseNumber(), oldPd.NextPulseDelta, oldPd.PrevPulseDelta, longbits.Bits256{})
 		pulseSlot       = conveyor.NewPresentPulseSlot(nil, pd.AsRange())
-		smObjectID      = gen.UniqueIDWithPulse(pd.PulseNumber)
-		smGlobalRef     = reference.NewSelf(smObjectID)
-		smObject        = object.NewStateMachineObject(smGlobalRef)
+		outgoingRef     = gen.UniqueIDWithPulse(oldPd.PulseNumber)
+		objectRef       = gen.UniqueReference()
+		smObject        = object.NewStateMachineObject(objectRef)
 		sharedStateData = smachine.NewUnboundSharedData(&smObject.SharedState)
 
 		callFlags = payload.BuildCallFlags(contract.CallIntolerable, contract.CallDirty)
@@ -257,19 +259,24 @@ func TestSMExecute_StepTakeLockGoesToDeduplicationForRequestWithRepeatedCallFlag
 
 	smObjectAccessor := object.SharedStateAccessor{SharedDataLink: sharedStateData}
 	request := &payload.VCallRequest{
-		CallType:            payload.CTConstructor,
+		CallType:            payload.CTMethod,
+		Callee:              objectRef,
 		CallFlags:           callFlags,
 		CallSiteDeclaration: testwallet.GetClass(),
-		CallSiteMethod:      "New",
-		CallOutgoing:        smObjectID,
+		CallSiteMethod:      "Method",
+		CallOutgoing:        outgoingRef,
 		Arguments:           insolar.MustSerialize([]interface{}{}),
-		CallRequestFlags:    payload.BuildCallRequestFlags(payload.SendResultDefault, payload.RepeatedCall),
 	}
 
 	smExecute := SMExecute{
 		Payload:           request,
 		pulseSlot:         &pulseSlot,
 		objectSharedState: smObjectAccessor,
+
+		methodIsolation: contract.MethodIsolation{
+			Interference: callFlags.GetInterference(),
+			State:        callFlags.GetState(),
+		},
 	}
 
 	smExecute = expectedInitState(ctx, smExecute)
@@ -280,6 +287,6 @@ func TestSMExecute_StepTakeLockGoesToDeduplicationForRequestWithRepeatedCallFlag
 			AcquireMock.Return(true).
 			JumpMock.Set(testutils.AssertJumpStep(t, smExecute.stepDeduplicate))
 
-		smExecute.stepTakeLock(execCtx)
+		smExecute.stepIsolationNegotiation(execCtx)
 	}
 }

--- a/ledger-core/virtual/execute/migration_test.go
+++ b/ledger-core/virtual/execute/migration_test.go
@@ -6,12 +6,9 @@
 package execute
 
 import (
-	"reflect"
-	"runtime"
 	"testing"
 
 	"github.com/gojuno/minimock/v3"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/insolar/assured-ledger/ledger-core/application/builtin/proxy/testwallet"
@@ -25,6 +22,7 @@ import (
 	"github.com/insolar/assured-ledger/ledger-core/pulse"
 	"github.com/insolar/assured-ledger/ledger-core/runner/executionevent"
 	"github.com/insolar/assured-ledger/ledger-core/runner/executionupdate"
+	"github.com/insolar/assured-ledger/ledger-core/testutils"
 	"github.com/insolar/assured-ledger/ledger-core/testutils/gen"
 	"github.com/insolar/assured-ledger/ledger-core/testutils/stepchecker"
 	"github.com/insolar/assured-ledger/ledger-core/vanilla/longbits"
@@ -100,10 +98,7 @@ func TestSMExecute_MigrationDuringSendOutgoing(t *testing.T) {
 			}).SleepMock.Set(
 			func() (c1 smachine.ConditionalBuilder) {
 				return smachine.NewStateConditionalBuilderMock(t).
-					ThenJumpMock.Set(func(s1 smachine.StateFunc) (s2 smachine.StateUpdate) {
-					assert.Equal(t, runtime.FuncForPC(reflect.ValueOf(smExecute.stepExecuteContinue).Pointer()).Name(), runtime.FuncForPC(reflect.ValueOf(s1).Pointer()).Name())
-					return smachine.StateUpdate{}
-				})
+					ThenJumpMock.Set(testutils.AssertJumpStep(t, smExecute.stepExecuteContinue))
 			})
 
 		smExecute.stepSendOutgoing(execCtx)
@@ -123,10 +118,7 @@ func TestSMExecute_MigrationDuringSendOutgoing(t *testing.T) {
 			SleepMock.Set(
 			func() (c1 smachine.ConditionalBuilder) {
 				return smachine.NewStateConditionalBuilderMock(t).
-					ThenJumpMock.Set(func(s1 smachine.StateFunc) (s2 smachine.StateUpdate) {
-					assert.Equal(t, runtime.FuncForPC(reflect.ValueOf(smExecute.stepExecuteContinue).Pointer()).Name(), runtime.FuncForPC(reflect.ValueOf(s1).Pointer()).Name())
-					return smachine.StateUpdate{}
-				})
+					ThenJumpMock.Set(testutils.AssertJumpStep(t, smExecute.stepExecuteContinue))
 			})
 
 		smExecute.stepSendOutgoing(execCtx)

--- a/ledger-core/virtual/handlers/vdelegatedcallrequest.go
+++ b/ledger-core/virtual/handlers/vdelegatedcallrequest.go
@@ -114,10 +114,6 @@ func (s *SMVDelegatedCallRequest) stepProcessRequest(ctx smachine.ExecutionConte
 	)
 
 	action := func(state *object.SharedState) {
-		if state.GetState() != object.HasState {
-			panic(throw.IllegalState())
-		}
-
 		var (
 			oldestPulse  pulse.Number
 			pendingList  *object.RequestList


### PR DESCRIPTION
**- What I did**
fixed some execution errors:
- proper deduplication for requests that comes from previous pulses
- proper object descriptor class getter
- leaking migration