### PR TITLE
NOISSUE: Enable logging for expired async callbacks

### DIFF
--- a/ledger-core/conveyor/smachine/api_logger.go
+++ b/ledger-core/conveyor/smachine/api_logger.go
@@ -58,12 +58,15 @@ func (v StepLoggerFlags) ErrorFlags() StepLoggerFlags {
 }
 
 const (
-	StepLoggerAdapterSyncCall    StepLoggerFlags = 0
-	StepLoggerAdapterNotifyCall                  = stepLoggerUpdateAdapterBit0
-	StepLoggerAdapterAsyncCall                   = stepLoggerUpdateAdapterBit2
-	StepLoggerAdapterAsyncResult                 = stepLoggerUpdateAdapterBit2 | stepLoggerUpdateAdapterBit1
-	StepLoggerAdapterAsyncCancel                 = stepLoggerUpdateAdapterBit2 | stepLoggerUpdateAdapterBit1 | stepLoggerUpdateAdapterBit0
+	StepLoggerAdapterSyncCall           StepLoggerFlags = 0
+	StepLoggerAdapterNotifyCall                         = stepLoggerUpdateAdapterBit0
+	StepLoggerAdapterAsyncCall                          = stepLoggerUpdateAdapterBit2
+	StepLoggerAdapterAsyncResult                        = stepLoggerUpdateAdapterBit2 | stepLoggerUpdateAdapterBit1
+	StepLoggerAdapterAsyncCancel                        = stepLoggerUpdateAdapterBit2 | stepLoggerUpdateAdapterBit1 | stepLoggerUpdateAdapterBit0
+	StepLoggerAdapterAsyncExpiredResult                 = stepLoggerUpdateAdapterBit1
+	StepLoggerAdapterAsyncExpiredCancel                 = stepLoggerUpdateAdapterBit1 | stepLoggerUpdateAdapterBit0
 )
+
 const StepLoggerAdapterMask = stepLoggerUpdateAdapterBit0 | stepLoggerUpdateAdapterBit1 | stepLoggerUpdateAdapterBit2
 
 func (v StepLoggerFlags) AdapterFlags() StepLoggerFlags {
@@ -340,6 +343,10 @@ func (v StepLoggerFlags) FormatAdapterForLog() string {
 		return "async-result"
 	case StepLoggerAdapterAsyncCancel:
 		return "async-cancel"
+	case StepLoggerAdapterAsyncExpiredResult:
+		return "async-expired-result"
+	case StepLoggerAdapterAsyncExpiredCancel:
+		return "async-expired-cancel"
 	}
 	return ""
 }

--- a/ledger-core/conveyor/smachine/exec_adapter_call.go
+++ b/ledger-core/conveyor/smachine/exec_adapter_call.go
@@ -55,10 +55,11 @@ func (c AdapterCall) DelegateAndSendResult(defaultNestedFn CreateFactoryFunc, de
 	switch {
 	case err == nil:
 		return func() {
-			if !c.Callback.IsCancelled() {
+			if c.Callback.IsCancelled() {
+				c.Callback.SendCancel()
+			} else {
 				c.Callback.SendResult(result)
 			}
-			c.Callback.SendCancel()
 		}, nil
 	case err == ErrCancelledCall:
 		return c.Callback.SendCancel, nil

--- a/ledger-core/conveyor/smachine/exec_adapter_callback.go
+++ b/ledger-core/conveyor/smachine/exec_adapter_callback.go
@@ -13,7 +13,7 @@ import (
 	"github.com/insolar/assured-ledger/ledger-core/vanilla/synckit"
 )
 
-type AdapterCallbackFunc func(AsyncResultFunc, error) bool
+type AdapterCallbackFunc func(isValid bool, fn AsyncResultFunc, err error) bool
 
 func NewAdapterCallback(adapterID AdapterID, caller StepLink, callbackOverride AdapterCallbackFunc, flags AsyncCallFlags,
 	nestedFn CreateFactoryFunc) *AdapterCallback {
@@ -102,9 +102,12 @@ func (c *AdapterCallback) callback(isCancel bool, resultFn AsyncResultFunc, err 
 
 	switch {
 	case !c.canCall():
+		if c.callbackFn != nil {
+			c.callbackFn(false, resultFn, err)
+		}
 		return
 	case c.callbackFn != nil:
-		if c.callbackFn(resultFn, err) {
+		if c.callbackFn(true, resultFn, err) {
 			return
 		}
 	}

--- a/ledger-core/testutils/slotdebugger/smhelper.go
+++ b/ledger-core/testutils/slotdebugger/smhelper.go
@@ -205,6 +205,8 @@ func (w StateMachineHelper) AfterResultOfFirstAsyncCall(id smachine.AdapterID) f
 				panic(throw.FailHere("duplicate async call id"))
 			case smachine.StepLoggerAdapterAsyncCancel:
 				panic(throw.FailHere("async call was cancelled"))
+			case smachine.StepLoggerAdapterAsyncExpiredCancel, smachine.StepLoggerAdapterAsyncExpiredResult:
+				panic(throw.FailHere("async callback has expired"))
 			case smachine.StepLoggerAdapterAsyncResult:
 				return true
 			}


### PR DESCRIPTION
**- What I did**
* added expired-cancel and expired-result statuses
