### PR TITLE
PLAT-480: missing return could result in illegal state

### DIFF
--- a/ledger-core/virtual/execute/delegatedtokenrequest.go
+++ b/ledger-core/virtual/execute/delegatedtokenrequest.go
@@ -107,7 +107,7 @@ func (s *SMDelegatedTokenRequest) stepSendRequest(ctx smachine.ExecutionContext)
 
 func (s *SMDelegatedTokenRequest) stepProcessResult(ctx smachine.ExecutionContext) smachine.StateUpdate {
 	if s.response == nil {
-		ctx.Sleep().ThenRepeat()
+		return ctx.Sleep().ThenRepeat()
 	}
 
 	return ctx.Stop()


### PR DESCRIPTION
early return from sub-SM without response, calling SM (SM Execute)
panics and stops execution
