### PR TITLE
PLAT-479: Send correct pending counters in VStateReport when pulse changed

### DIFF
--- a/ledger-core/virtual/execute/delegatedtokenrequest.go
+++ b/ledger-core/virtual/execute/delegatedtokenrequest.go
@@ -107,7 +107,7 @@ func (s *SMDelegatedTokenRequest) stepSendRequest(ctx smachine.ExecutionContext)
 
 func (s *SMDelegatedTokenRequest) stepProcessResult(ctx smachine.ExecutionContext) smachine.StateUpdate {
 	if s.response == nil {
-		ctx.Sleep().ThenRepeat()
+		return ctx.Sleep().ThenRepeat()
 	}
 
 	return ctx.Stop()

--- a/ledger-core/virtual/handlers/vdelegatedcallrequest.go
+++ b/ledger-core/virtual/handlers/vdelegatedcallrequest.go
@@ -114,9 +114,9 @@ func (s *SMVDelegatedCallRequest) stepProcessRequest(ctx smachine.ExecutionConte
 
 	action := func(state *object.SharedState) {
 		var (
-			oldestPulse  pulse.Number
-			pendingList  *object.RequestList
-			pendingCount uint8
+			oldestPulse                  pulse.Number
+			pendingList                  *object.RequestList
+			previousExecutorPendingCount int
 		)
 
 		callTolerance := s.Payload.CallFlags.GetInterference()
@@ -125,11 +125,11 @@ func (s *SMVDelegatedCallRequest) stepProcessRequest(ctx smachine.ExecutionConte
 		case contract.CallTolerable:
 			pendingList = state.PendingTable.GetList(contract.CallTolerable)
 			oldestPulse = state.OrderedPendingEarliestPulse
-			pendingCount = state.ActiveOrderedPendingCount
+			previousExecutorPendingCount = int(state.PreviousExecutorOrderedPendingCount)
 		case contract.CallIntolerable:
 			pendingList = state.PendingTable.GetList(contract.CallIntolerable)
 			oldestPulse = state.UnorderedPendingEarliestPulse
-			pendingCount = state.ActiveUnorderedPendingCount
+			previousExecutorPendingCount = int(state.PreviousExecutorUnorderedPendingCount)
 		default:
 			panic(throw.Unsupported())
 		}
@@ -140,7 +140,7 @@ func (s *SMVDelegatedCallRequest) stepProcessRequest(ctx smachine.ExecutionConte
 		}
 
 		// pendingList already full
-		if pendingList.Count() == int(pendingCount) && !pendingList.Exist(s.Payload.CallOutgoing) {
+		if pendingList.Count() == previousExecutorPendingCount && !pendingList.Exist(s.Payload.CallOutgoing) {
 			resultCheck = delegationFullTable
 			return
 		}
@@ -154,7 +154,7 @@ func (s *SMVDelegatedCallRequest) stepProcessRequest(ctx smachine.ExecutionConte
 			return
 		}
 
-		if pendingList.Count() == int(pendingCount) {
+		if pendingList.Count() == previousExecutorPendingCount {
 			state.SetPendingListFilled(ctx, callTolerance)
 		}
 	}

--- a/ledger-core/virtual/handlers/vdelegatedcallrequest_test.go
+++ b/ledger-core/virtual/handlers/vdelegatedcallrequest_test.go
@@ -220,16 +220,16 @@ func TestSMVDelegatedCallRequest(t *testing.T) {
 				unorderedBargeIn = smachine.BargeIn{}
 				sharedState      = &object.SharedState{
 					Info: object.Info{
-						PendingTable:                       tc.PendingRequestTable,
-						OrderedPendingEarliestPulse:        tc.OrderedPendingEarliestPulse,
-						UnorderedPendingEarliestPulse:      tc.UnorderedPendingEarliestPulse,
-						ActiveOrderedPendingCount:          tc.ActiveOrderedPendingCount,
-						ActiveUnorderedPendingCount:        tc.ActiveUnorderedPendingCount,
-						KnownRequests:                      object.NewRequestTable(),
-						ReadyToWork:                        smsync.NewConditional(1, "ReadyToWork").SyncLink(),
-						OrderedExecute:                     smsync.NewConditional(1, "MutableExecution").SyncLink(),
-						OrderedPendingListFilledCallback:   orderedBargeIn,
-						UnorderedPendingListFilledCallback: unorderedBargeIn,
+						PendingTable:                          tc.PendingRequestTable,
+						OrderedPendingEarliestPulse:           tc.OrderedPendingEarliestPulse,
+						UnorderedPendingEarliestPulse:         tc.UnorderedPendingEarliestPulse,
+						PreviousExecutorOrderedPendingCount:   tc.ActiveOrderedPendingCount,
+						PreviousExecutorUnorderedPendingCount: tc.ActiveUnorderedPendingCount,
+						KnownRequests:                         object.NewRequestTable(),
+						ReadyToWork:                           smsync.NewConditional(1, "ReadyToWork").SyncLink(),
+						OrderedExecute:                        smsync.NewConditional(1, "MutableExecution").SyncLink(),
+						OrderedPendingListFilledCallback:      orderedBargeIn,
+						UnorderedPendingListFilledCallback:    unorderedBargeIn,
 					},
 				}
 				callFlags = tc.callFlags

--- a/ledger-core/virtual/handlers/vdelegatedrequestfinished_test.go
+++ b/ledger-core/virtual/handlers/vdelegatedrequestfinished_test.go
@@ -62,11 +62,12 @@ func TestSMVDelegatedRequestFinished_TolerableUpdateSharedState_OneActiveCounter
 		callMode    = contract.CallTolerable
 	)
 
-	smObject.ActiveOrderedPendingCount = 1
+	smObject.PreviousExecutorOrderedPendingCount = 1
 
 	table := smObject.PendingTable.GetList(callMode)
 	table.Add(smExecID)
 	require.Equal(t, 1, table.Count())
+	require.Equal(t, 1, table.CountActive())
 
 	sm := SMVDelegatedRequestFinished{
 		Payload: &payload.VDelegatedRequestFinished{
@@ -82,7 +83,8 @@ func TestSMVDelegatedRequestFinished_TolerableUpdateSharedState_OneActiveCounter
 	sm.updateSharedState(execCtx, &smObject.SharedState)
 
 	require.Equal(t, 1, table.CountFinish())
-	require.Equal(t, uint8(0), smObject.ActiveOrderedPendingCount)
+	require.Equal(t, 0, table.CountActive())
+	require.Equal(t, uint8(1), smObject.PreviousExecutorOrderedPendingCount)
 	mc.Finish()
 }
 
@@ -97,11 +99,15 @@ func TestSMVDelegatedRequestFinished_TolerableUpdateSharedState_ManyActiveCounte
 		callMode    = contract.CallTolerable
 	)
 
-	smObject.ActiveOrderedPendingCount = 2
+	smObject.PreviousExecutorOrderedPendingCount = 2
 
 	table := smObject.PendingTable.GetList(callMode)
 	table.Add(smExecID)
 	require.Equal(t, 1, table.Count())
+	require.Equal(t, 1, table.CountActive())
+	table.Add(reference.NewSelf(gen.UniqueIDWithPulse(pd.PulseNumber)))
+	require.Equal(t, 2, table.Count())
+	require.Equal(t, 2, table.CountActive())
 
 	sm := SMVDelegatedRequestFinished{
 		Payload: &payload.VDelegatedRequestFinished{
@@ -116,7 +122,8 @@ func TestSMVDelegatedRequestFinished_TolerableUpdateSharedState_ManyActiveCounte
 	sm.updateSharedState(execCtx, &smObject.SharedState)
 
 	require.Equal(t, 1, table.CountFinish())
-	require.Equal(t, uint8(1), smObject.ActiveOrderedPendingCount)
+	require.Equal(t, 1, table.CountActive())
+	require.Equal(t, uint8(2), smObject.PreviousExecutorOrderedPendingCount)
 	mc.Finish()
 }
 
@@ -131,11 +138,12 @@ func TestSMVDelegatedRequestFinished_IntolerableUpdateSharedStateUpdatePendingTa
 		callMode    = contract.CallIntolerable
 	)
 
-	smObject.ActiveUnorderedPendingCount = 1
+	smObject.PreviousExecutorUnorderedPendingCount = 1
 
 	table := smObject.PendingTable.GetList(callMode)
 	table.Add(smExecID)
 	require.Equal(t, 1, table.Count())
+	require.Equal(t, 1, table.CountActive())
 
 	sm := SMVDelegatedRequestFinished{
 		Payload: &payload.VDelegatedRequestFinished{
@@ -148,6 +156,7 @@ func TestSMVDelegatedRequestFinished_IntolerableUpdateSharedStateUpdatePendingTa
 	sm.updateSharedState(execCtx, &smObject.SharedState)
 
 	require.Equal(t, 1, table.CountFinish())
-	require.Equal(t, uint8(0), smObject.ActiveUnorderedPendingCount)
+	require.Equal(t, 0, table.CountActive())
+	require.Equal(t, uint8(1), smObject.PreviousExecutorUnorderedPendingCount)
 	mc.Finish()
 }

--- a/ledger-core/virtual/handlers/vstatereport.go
+++ b/ledger-core/virtual/handlers/vstatereport.go
@@ -122,8 +122,8 @@ func (s *SMVStateReport) updateSharedState(
 		panic(throw.IllegalState())
 	}
 
-	state.ActiveUnorderedPendingCount = uint8(s.Payload.UnorderedPendingCount)
-	state.ActiveOrderedPendingCount = uint8(s.Payload.OrderedPendingCount)
+	state.PreviousExecutorUnorderedPendingCount = uint8(s.Payload.UnorderedPendingCount)
+	state.PreviousExecutorOrderedPendingCount = uint8(s.Payload.OrderedPendingCount)
 
 	state.OrderedPendingEarliestPulse = s.Payload.OrderedPendingEarliestPulse
 	state.UnorderedPendingEarliestPulse = s.Payload.UnorderedPendingEarliestPulse

--- a/ledger-core/virtual/handlers/vstatereport_test.go
+++ b/ledger-core/virtual/handlers/vstatereport_test.go
@@ -54,8 +54,8 @@ func TestVStateReport_CreateObjectWithoutState(t *testing.T) {
 	require.Equal(t, object.Unknown, smObject.GetState())
 	smVStateReport.stepProcess(execCtx)
 	require.Equal(t, object.Empty, smObject.GetState())
-	require.Equal(t, uint8(1), smObject.ActiveUnorderedPendingCount)
-	require.Equal(t, uint8(1), smObject.ActiveOrderedPendingCount)
+	require.Equal(t, uint8(1), smObject.PreviousExecutorUnorderedPendingCount)
+	require.Equal(t, uint8(1), smObject.PreviousExecutorOrderedPendingCount)
 	require.Nil(t, smObject.Descriptor())
 
 	require.NoError(t, catalog.CheckDone())

--- a/ledger-core/virtual/object/object.go
+++ b/ledger-core/virtual/object/object.go
@@ -414,7 +414,7 @@ func (sm *SMObject) migrate(ctx smachine.MigrationContext) smachine.StateUpdate 
 		Reference: sm.Reference,
 	}
 
-	sm.correctionPendingCounters(ctx.Log())
+	sm.countActivePendings(ctx.Log())
 	smf.Report = sm.BuildStateReport()
 	if sm.Descriptor() != nil {
 		smf.Report.ProvidedContent.LatestDirtyState = sm.BuildLatestDirtyState()
@@ -443,7 +443,7 @@ type pendingCountersWarnMsg struct {
 	CountActive  uint8
 }
 
-func (sm *SMObject) correctionPendingCounters(logger smachine.Logger) {
+func (sm *SMObject) countActivePendings(logger smachine.Logger) {
 	unorderedCountActive := uint8(sm.PendingTable.GetList(contract.CallIntolerable).CountActive())
 	if sm.ActiveUnorderedPendingCount != unorderedCountActive {
 		logger.Warn(pendingCountersWarnMsg{

--- a/ledger-core/virtual/object/object_migration_test.go
+++ b/ledger-core/virtual/object/object_migration_test.go
@@ -81,6 +81,7 @@ func TestSMObject_MigrationCreateStateReport_IfStateMissing(t *testing.T) {
 
 	migrationCtx := smachine.NewMigrationContextMock(mc).
 		JumpMock.Return(smachine.StateUpdate{}).UnpublishAllMock.Return().
+		LogMock.Return(smachine.Logger{}).
 		ShareMock.Return(smachine.NewUnboundSharedData(&report)).
 		PublishMock.Set(func(key interface{}, data interface{}) (b1 bool) {
 		assert.Equal(t, finalizedstate.BuildReportKey(report.Object, smObject.pulseSlot.PulseData().PulseNumber), key)
@@ -127,6 +128,7 @@ func TestSMObject_MigrationCreateStateReport_IfStateEmptyAndCountersSet(t *testi
 
 	migrationCtx := smachine.NewMigrationContextMock(mc).
 		JumpMock.Return(smachine.StateUpdate{}).UnpublishAllMock.Return().
+		LogMock.Return(smachine.Logger{}).
 		ShareMock.Return(smachine.NewUnboundSharedData(&report)).
 		PublishMock.Set(func(key interface{}, data interface{}) (b1 bool) {
 		assert.Equal(t, finalizedstate.BuildReportKey(report.Object, smObject.pulseSlot.PulseData().PulseNumber), key)

--- a/ledger-core/virtual/object/object_test.go
+++ b/ledger-core/virtual/object/object_test.go
@@ -112,7 +112,7 @@ func Test_PendingBlocksExecution(t *testing.T) {
 		smObject.Init(initCtx)
 	}
 
-	smObject.SharedState.ActiveOrderedPendingCount = 1
+	smObject.SharedState.PreviousExecutorOrderedPendingCount = 1
 	smObject.SharedState.SetState(HasState)
 
 	{ // we should be able to start
@@ -168,7 +168,7 @@ func TestSMObject_Semi_CheckAwaitDelegateIsStarted(t *testing.T) {
 	)
 
 	smObject.SetState(HasState)
-	smObject.ActiveOrderedPendingCount = 1
+	smObject.PreviousExecutorOrderedPendingCount = 1
 
 	slotMachine := slotdebugger.New(ctx, t, true)
 	slotMachine.InitEmptyMessageSender(mc)
@@ -219,8 +219,8 @@ func TestSMObject_stepGotState_Set_PendingListFilled(t *testing.T) {
 
 	{
 
-		smObject.SharedState.ActiveOrderedPendingCount = 0
-		smObject.SharedState.ActiveUnorderedPendingCount = 0
+		smObject.SharedState.PreviousExecutorOrderedPendingCount = 0
+		smObject.SharedState.PreviousExecutorUnorderedPendingCount = 0
 
 		execCtx := smachine.NewExecutionContextMock(mc).
 			JumpMock.Set(stepChecker.CheckJumpW(t))
@@ -237,11 +237,11 @@ func TestSMObject_correctionPendingCounters(t *testing.T) {
 	)
 
 	smObject := NewStateMachineObject(smGlobalRef)
-	smObject.ActiveUnorderedPendingCount = 2
-	smObject.ActiveOrderedPendingCount = 2
+	smObject.PreviousExecutorUnorderedPendingCount = 2
+	smObject.PreviousExecutorOrderedPendingCount = 2
 	smObject.PendingTable.GetList(contract.CallIntolerable).Add(gen.UniqueReference())
 	smObject.PendingTable.GetList(contract.CallTolerable).Add(gen.UniqueReference())
 	smObject.countActivePendings(smachine.Logger{})
-	require.Equal(t, uint8(1), smObject.ActiveUnorderedPendingCount)
-	require.Equal(t, uint8(1), smObject.ActiveOrderedPendingCount)
+	require.Equal(t, uint8(1), smObject.PreviousExecutorUnorderedPendingCount)
+	require.Equal(t, uint8(1), smObject.PreviousExecutorOrderedPendingCount)
 }

--- a/ledger-core/virtual/object/object_test.go
+++ b/ledger-core/virtual/object/object_test.go
@@ -229,7 +229,7 @@ func TestSMObject_stepGotState_Set_PendingListFilled(t *testing.T) {
 	}
 }
 
-func TestSMObject_correctionPendingCounters(t *testing.T) {
+func TestSMObject_checkPendingCounters_DontChangeIt(t *testing.T) {
 	var (
 		pd          = pulse.NewPulsarData(pulse.OfNow(), 10, 10, longbits.Bits256{})
 		smObjectID  = gen.UniqueIDWithPulse(pd.PulseNumber)
@@ -242,6 +242,6 @@ func TestSMObject_correctionPendingCounters(t *testing.T) {
 	smObject.PendingTable.GetList(contract.CallIntolerable).Add(gen.UniqueReference())
 	smObject.PendingTable.GetList(contract.CallTolerable).Add(gen.UniqueReference())
 	smObject.checkPendingCounters(smachine.Logger{})
-	require.Equal(t, uint8(1), smObject.PreviousExecutorUnorderedPendingCount)
-	require.Equal(t, uint8(1), smObject.PreviousExecutorOrderedPendingCount)
+	require.Equal(t, uint8(2), smObject.PreviousExecutorUnorderedPendingCount)
+	require.Equal(t, uint8(2), smObject.PreviousExecutorOrderedPendingCount)
 }

--- a/ledger-core/virtual/object/object_test.go
+++ b/ledger-core/virtual/object/object_test.go
@@ -241,7 +241,7 @@ func TestSMObject_correctionPendingCounters(t *testing.T) {
 	smObject.PreviousExecutorOrderedPendingCount = 2
 	smObject.PendingTable.GetList(contract.CallIntolerable).Add(gen.UniqueReference())
 	smObject.PendingTable.GetList(contract.CallTolerable).Add(gen.UniqueReference())
-	smObject.countActivePendings(smachine.Logger{})
+	smObject.checkPendingCounters(smachine.Logger{})
 	require.Equal(t, uint8(1), smObject.PreviousExecutorUnorderedPendingCount)
 	require.Equal(t, uint8(1), smObject.PreviousExecutorOrderedPendingCount)
 }

--- a/ledger-core/virtual/object/object_test.go
+++ b/ledger-core/virtual/object/object_test.go
@@ -241,7 +241,7 @@ func TestSMObject_correctionPendingCounters(t *testing.T) {
 	smObject.ActiveOrderedPendingCount = 2
 	smObject.PendingTable.GetList(contract.CallIntolerable).Add(gen.UniqueReference())
 	smObject.PendingTable.GetList(contract.CallTolerable).Add(gen.UniqueReference())
-	smObject.correctionPendingCounters(smachine.Logger{})
+	smObject.countActivePendings(smachine.Logger{})
 	require.Equal(t, uint8(1), smObject.ActiveUnorderedPendingCount)
 	require.Equal(t, uint8(1), smObject.ActiveOrderedPendingCount)
 }

--- a/ledger-core/virtual/object/request_table.go
+++ b/ledger-core/virtual/object/request_table.go
@@ -44,6 +44,8 @@ type isActive bool
 
 type RequestList struct {
 	earliestPulse pulse.Number
+	countActive   int
+	countFinish   int
 	requests      map[reference.Global]isActive
 }
 
@@ -66,6 +68,7 @@ func (rl *RequestList) Add(ref reference.Global) bool {
 	}
 
 	rl.requests[ref] = true
+	rl.countActive++
 
 	requestPulseNumber := ref.GetLocal().GetPulseNumber()
 	if rl.earliestPulse == 0 || requestPulseNumber < rl.earliestPulse {
@@ -98,6 +101,8 @@ func (rl *RequestList) Finish(ref reference.Global) bool {
 	}
 
 	rl.requests[ref] = false
+	rl.countActive--
+	rl.countFinish++
 
 	if ref.GetLocal().GetPulseNumber() == rl.earliestPulse {
 		rl.calculateEarliestPulse()
@@ -111,23 +116,11 @@ func (rl *RequestList) Count() int {
 }
 
 func (rl *RequestList) CountFinish() int {
-	var count int
-	for _, requestIsActive := range rl.requests {
-		if !requestIsActive {
-			count++
-		}
-	}
-	return count
+	return rl.countFinish
 }
 
 func (rl *RequestList) CountActive() int {
-	var count int
-	for _, requestIsActive := range rl.requests {
-		if requestIsActive {
-			count++
-		}
-	}
-	return count
+	return rl.countActive
 }
 
 func (rl *RequestList) EarliestPulse() pulse.Number {

--- a/ledger-core/virtual/object/request_table_test.go
+++ b/ledger-core/virtual/object/request_table_test.go
@@ -56,22 +56,29 @@ func TestRequestList(t *testing.T) {
 	rl := NewRequestList()
 	require.Equal(t, 0, rl.Count())
 	require.Equal(t, 0, rl.CountFinish())
+	require.Equal(t, 0, rl.CountActive())
 	require.Equal(t, pulse.Number(0), rl.EarliestPulse())
 
 	require.Equal(t, true, rl.Add(RefOne))
 	require.Equal(t, true, rl.Exist(RefOne))
 	require.Equal(t, 1, rl.Count())
+	require.Equal(t, 0, rl.CountFinish())
+	require.Equal(t, 1, rl.CountActive())
 	require.Equal(t, nextPulseNumber, rl.EarliestPulse())
 
 	require.Equal(t, false, rl.Add(RefOne))
 	require.Equal(t, true, rl.Exist(RefOne))
 	require.Equal(t, 1, rl.Count())
+	require.Equal(t, 0, rl.CountFinish())
+	require.Equal(t, 1, rl.CountActive())
 	require.Equal(t, nextPulseNumber, rl.EarliestPulse())
 
 	require.Equal(t, true, rl.Add(RefOld))
 	require.Equal(t, true, rl.Exist(RefOne))
 	require.Equal(t, true, rl.Exist(RefOld))
 	require.Equal(t, 2, rl.Count())
+	require.Equal(t, 0, rl.CountFinish())
+	require.Equal(t, 2, rl.CountActive())
 	require.Equal(t, pd.PulseNumber, rl.EarliestPulse())
 
 	require.Equal(t, true, rl.Add(RefTwo))
@@ -81,6 +88,7 @@ func TestRequestList(t *testing.T) {
 	require.Equal(t, 3, rl.Count())
 	require.Equal(t, pd.PulseNumber, rl.EarliestPulse())
 	require.Equal(t, 0, rl.CountFinish())
+	require.Equal(t, 3, rl.CountActive())
 
 	rl.Finish(RefOne)
 	require.Equal(t, pd.PulseNumber, rl.EarliestPulse()) // doesn't change
@@ -90,6 +98,8 @@ func TestRequestList(t *testing.T) {
 	// try to finish ref that not in list
 	successFinish := rl.Finish(reference.NewSelf(gen.UniqueIDWithPulse(currentPulse)))
 	require.Equal(t, false, successFinish)
+	require.Equal(t, 1, rl.CountFinish())
+	require.Equal(t, 2, rl.CountActive())
 }
 
 func TestRequestList_Finish(t *testing.T) {
@@ -109,13 +119,17 @@ func TestRequestList_Finish(t *testing.T) {
 	require.Equal(t, true, rl.Add(RefOne))
 	require.Equal(t, 1, rl.Count())
 	require.Equal(t, currentPulse, rl.earliestPulse)
+	require.Equal(t, 0, rl.CountFinish())
+	require.Equal(t, 1, rl.CountActive())
 
 	require.Equal(t, true, rl.Add(RefTwo))
 	require.Equal(t, 2, rl.Count())
 	require.Equal(t, currentPulse, rl.earliestPulse)
 	require.Equal(t, 0, rl.CountFinish())
+	require.Equal(t, 2, rl.CountActive())
 
 	rl.Finish(RefOne)
 	require.Equal(t, 1, rl.CountFinish())
+	require.Equal(t, 1, rl.CountActive())
 	require.Equal(t, nextPulseNumber, rl.earliestPulse)
 }


### PR DESCRIPTION
**- What I did**
Send VStateReport with pending counters witch was registered as delegated and does not finished yet. This values stored in PendingTable. Active(Un|O)rderedPendingCount was renamed to PreviousExecutor(Un|O)rderedPendingCount and used as constant

**- How I did it**
Check values of counters with values of active counters in table of pending execution. Logging warning if values mismatched and correct it.

**- How to verify it**
Run test. Addition test case will be in PLAT-471

**- Description for the changelog**

