### PR TITLE
PLAT-490: BargeInCallbackFunc is synchronized with registering SM

### DIFF
--- a/ledger-core/application/testwalletapi/statemachine/statemachine.go
+++ b/ledger-core/application/testwalletapi/statemachine/statemachine.go
@@ -81,9 +81,10 @@ func (s *SMTestAPICall) stepRegisterBargeIn(ctx smachine.ExecutionContext) smach
 		if !ok || res == nil {
 			panic(throw.IllegalValue())
 		}
-		s.responsePayload = *res
 
 		return func(ctx smachine.BargeInContext) smachine.StateUpdate {
+			s.responsePayload = *res
+
 			return ctx.WakeUp()
 		}
 	})

--- a/ledger-core/virtual/execute/delegatedtokenrequest.go
+++ b/ledger-core/virtual/execute/delegatedtokenrequest.go
@@ -76,9 +76,10 @@ func (s *SMDelegatedTokenRequest) stepRegisterBargeIn(ctx smachine.ExecutionCont
 		if !ok || res == nil {
 			panic(throw.IllegalValue())
 		}
-		s.response = res
 
 		return func(ctx smachine.BargeInContext) smachine.StateUpdate {
+			s.response = res
+
 			return ctx.WakeUp()
 		}
 	})

--- a/ledger-core/virtual/execute/execute.go
+++ b/ledger-core/virtual/execute/execute.go
@@ -517,9 +517,10 @@ func (s *SMExecute) stepSendOutgoing(ctx smachine.ExecutionContext) smachine.Sta
 			if !ok || res == nil {
 				panic(throw.IllegalValue())
 			}
-			s.outgoingResult = res.ReturnArguments
 
 			return func(ctx smachine.BargeInContext) smachine.StateUpdate {
+				s.outgoingResult = res.ReturnArguments
+
 				return ctx.WakeUp()
 			}
 		})


### PR DESCRIPTION
writing into registering SM's fields from outside of smachine.BargeInCallbackFunc
is not safe
