### PR TITLE
PLAT-394, PLAT-507: constructor call with bad class ref returns an error

### DIFF
--- a/ledger-core/runner/runner.go
+++ b/ledger-core/runner/runner.go
@@ -10,12 +10,10 @@ import (
 	"context"
 	"sync"
 
-	"github.com/insolar/assured-ledger/ledger-core/reference"
-	errors "github.com/insolar/assured-ledger/ledger-core/vanilla/throw"
-
 	"github.com/insolar/assured-ledger/ledger-core/insolar/contract"
 	"github.com/insolar/assured-ledger/ledger-core/insolar/payload"
 	"github.com/insolar/assured-ledger/ledger-core/instrumentation/inslogger"
+	"github.com/insolar/assured-ledger/ledger-core/reference"
 	"github.com/insolar/assured-ledger/ledger-core/runner/call"
 	"github.com/insolar/assured-ledger/ledger-core/runner/execution"
 	"github.com/insolar/assured-ledger/ledger-core/runner/executor/builtin"
@@ -182,7 +180,7 @@ func (r *DefaultService) executeMethod(
 
 	classReference, err := objectDescriptor.Class()
 	if err != nil {
-		return nil, errors.W(err, "couldn't get class reference", ErrorDetail{DetailEmptyClassRef})
+		return nil, throw.W(err, "couldn't get class reference", ErrorDetail{DetailEmptyClassRef})
 	}
 	if classReference.IsEmpty() {
 		panic(throw.IllegalState())
@@ -190,12 +188,12 @@ func (r *DefaultService) executeMethod(
 
 	classDescriptor, codeDescriptor, err := r.Cache.ByClassRef(ctx, classReference)
 	if err != nil {
-		return nil, errors.W(err, "couldn't get descriptors", ErrorDetail{DetailBadClassRef})
+		return nil, throw.W(err, "couldn't get descriptors", ErrorDetail{DetailBadClassRef})
 	}
 
 	codeExecutor, err := r.Manager.GetExecutor(codeDescriptor.MachineType())
 	if err != nil {
-		return nil, errors.W(err, "couldn't get executor")
+		return nil, throw.W(err, "couldn't get executor")
 	}
 
 	logicContext := generateCallContext(ctx, id, executionContext, classDescriptor, codeDescriptor)
@@ -204,13 +202,13 @@ func (r *DefaultService) executeMethod(
 		ctx, logicContext, codeDescriptor.Ref(), objectDescriptor.Memory(), request.CallSiteMethod, request.Arguments,
 	)
 	if err != nil {
-		return nil, errors.W(err, "execution error")
+		return nil, throw.W(err, "execution error")
 	}
 	if len(result) == 0 {
-		return nil, errors.New("return of method is empty")
+		return nil, throw.E("return of method is empty")
 	}
 	if len(newData) == 0 {
-		return nil, errors.New("object state is empty")
+		return nil, throw.E("object state is empty")
 	}
 
 	// form and return result
@@ -237,22 +235,22 @@ func (r *DefaultService) executeConstructor(
 
 	classDescriptor, codeDescriptor, err := r.Cache.ByClassRef(ctx, request.Callee)
 	if err != nil {
-		return nil, errors.W(err, "couldn't get descriptors", ErrorDetail{DetailBadClassRef})
+		return nil, throw.W(err, "couldn't get descriptors", ErrorDetail{DetailBadClassRef})
 	}
 
 	codeExecutor, err := r.Manager.GetExecutor(codeDescriptor.MachineType())
 	if err != nil {
-		return nil, errors.W(err, "couldn't get executor")
+		return nil, throw.W(err, "couldn't get executor")
 	}
 
 	logicContext := generateCallContext(ctx, id, executionContext, classDescriptor, codeDescriptor)
 
 	newState, executionResult, err := codeExecutor.CallConstructor(ctx, logicContext, codeDescriptor.Ref(), request.CallSiteMethod, request.Arguments)
 	if err != nil {
-		return nil, errors.W(err, "execution error")
+		return nil, throw.W(err, "execution error")
 	}
 	if len(executionResult) == 0 {
-		return nil, errors.New("return of constructor is empty")
+		return nil, throw.E("return of constructor is empty")
 	}
 
 	// form and return executionResult

--- a/ledger-core/virtual/execute/execute.go
+++ b/ledger-core/virtual/execute/execute.go
@@ -9,7 +9,6 @@ package execute
 
 import (
 	"context"
-	"errors"
 
 	"github.com/insolar/assured-ledger/ledger-core/conveyor"
 	"github.com/insolar/assured-ledger/ledger-core/conveyor/smachine"
@@ -517,11 +516,10 @@ func (s *SMExecute) stepExecuteDecideNextStep(ctx smachine.ExecutionContext) sma
 		// send VCallResult here
 		return ctx.Jump(s.stepSaveNewObject)
 	case execution.Error:
-		var detail runner.ErrorDetail
-		if throw.FindDetail(newState.Error, &detail) {
-			switch detail.Type {
+		if d := new(runner.ErrorDetail); throw.FindDetail(newState.Error, d) {
+			switch d.Type {
 			case runner.DetailBadClassRef, runner.DetailEmptyClassRef:
-				s.prepareExecutionError(errors.New("bad class reference"))
+				s.prepareExecutionError(throw.E("bad class reference"))
 			}
 		} else {
 			s.prepareExecutionError(throw.W(newState.Error, "failed to execute request"))
@@ -634,7 +632,7 @@ func (s *SMExecute) stepSendOutgoing(ctx smachine.ExecutionContext) smachine.Sta
 		outgoingRef := reference.NewRecordOf(s.outgoing.Caller, s.outgoing.CallOutgoing)
 
 		if !ctx.PublishGlobalAliasAndBargeIn(outgoingRef, bargeInCallback) {
-			return ctx.Error(errors.New("failed to publish bargeInCallback"))
+			return ctx.Error(throw.E("failed to publish bargeInCallback"))
 		}
 	} else {
 		s.outgoing.CallRequestFlags = payload.BuildCallRequestFlags(payload.SendResultDefault, payload.RepeatedCall)

--- a/ledger-core/virtual/integration/utils/server.go
+++ b/ledger-core/virtual/integration/utils/server.go
@@ -259,6 +259,10 @@ func (s *Server) RandomLocalWithPulse() reference.Local {
 	return gen.UniqueLocalRefWithPulse(s.GetPulse().PulseNumber)
 }
 
+func (s *Server) RandomGlobalWithPulse() reference.Global {
+	return gen.UniqueGlobalRefWithPulse(s.GetPulse().PulseNumber)
+}
+
 func (s *Server) Stop() {
 	defer close(s.fullStop)
 


### PR DESCRIPTION
Added error instead of panic when failed to find contract descriptor.
Added test checking that constructor calls with empty or random class ref return an error.