### PR TITLE
PLAT-557 Provide pulse.Range for in-cache antique slots.

### DIFF
--- a/ledger-core/conveyor/pulse_data_holder.go
+++ b/ledger-core/conveyor/pulse_data_holder.go
@@ -71,7 +71,7 @@ func (p *futurePulseDataHolder) _pulseRange() (pulse.Range, PulseSlotState) {
 		case p.isPast:
 			panic(throw.IllegalState())
 		}
-		return p.pr, Future
+		return p.expected.AsRange(), Future
 	case p.isPast:
 		return p.pr, Past
 	default:

--- a/ledger-core/pulse/pulse_data.go
+++ b/ledger-core/pulse/pulse_data.go
@@ -136,9 +136,14 @@ func fixedPulseEntropy(v *longbits.Bits256, pn Number) {
 }
 
 func (r Data) EnsurePulseData() {
-	switch {
-	case r.isExpected():
+	if r.isExpected() {
 		panic("next delta can't be zero")
+	}
+	r.ensureRangeData()
+}
+
+func (r Data) ensureRangeData() {
+	switch {
 	case !r.PulseNumber.IsTimePulse():
 		panic("incorrect pulse number")
 	case !r.HasValidEpoch():

--- a/ledger-core/pulse/pulse_range.go
+++ b/ledger-core/pulse/pulse_range.go
@@ -15,7 +15,7 @@ type Range interface {
 	// LeftPrevDelta is PrevDelta associated with the left boundary (refers to a pulse _before_ the left boundary).
 	LeftPrevDelta() uint16
 
-	// RightBoundData returns a right bound of the range. MUST be a valid pulse data.
+	// RightBoundData returns a right bound of the range. MUST be a valid or expected pulse data.
 	RightBoundData() Data
 
 	// IsArticulated indicates that this range requires articulated pulses to be properly chained.
@@ -123,7 +123,7 @@ func checkSequence(data []Data) bool {
 var _ Range = OnePulseRange{}
 
 func NewOnePulseRange(data Data) OnePulseRange {
-	data.EnsurePulseData()
+	data.ensureRangeData()
 	return OnePulseRange{data}
 }
 
@@ -132,7 +132,7 @@ type OnePulseRange struct {
 }
 
 func (p OnePulseRange) IsValidNext(a Range) bool {
-	if p.data.NextPulseDelta != a.LeftPrevDelta() {
+	if p.data.NextPulseDelta == 0 || p.data.NextPulseDelta != a.LeftPrevDelta() {
 		return false
 	}
 	if n, ok := p.data.GetNextPulseNumber(); ok {

--- a/ledger-core/virtual/handlers/handle_meta.go
+++ b/ledger-core/virtual/handlers/handle_meta.go
@@ -64,8 +64,8 @@ func (f FactoryMeta) Process(msg *statemachine.DispatcherMessage, pr pulse.Range
 		messageType: fmt.Sprintf("id=%d, type=%s", payloadTypeID, payloadType.String()),
 	})
 
-	currentPulse := pr.RightBoundData().PulseNumber
-	if currentPulse != payloadMeta.Pulse {
+	targetPulse := pr.RightBoundData().PulseNumber
+	if targetPulse != payloadMeta.Pulse {
 		panic(throw.Impossible())
 	}
 
@@ -75,12 +75,12 @@ func (f FactoryMeta) Process(msg *statemachine.DispatcherMessage, pr pulse.Range
 			messageTypeID uint64
 			messageType   reflect.Type
 			incomingPulse pulse.Number
-			currentPulse  pulse.Number
+			targetPulse   pulse.Number
 		}{
 			messageTypeID: payloadTypeID,
 			messageType:   payloadType,
 			incomingPulse: payloadMeta.Pulse,
-			currentPulse:  pr.RightBoundData().PulseNumber,
+			targetPulse:   targetPulse,
 		}))
 
 		return pulse.Unknown, nil, nil
@@ -94,19 +94,19 @@ func (f FactoryMeta) Process(msg *statemachine.DispatcherMessage, pr pulse.Range
 	if pn, sm := func() (pulse.Number, smachine.StateMachine) {
 		switch obj := payloadObj.(type) {
 		case *payload.VCallRequest:
-			return currentPulse, &SMVCallRequest{Meta: payloadMeta, Payload: obj}
+			return targetPulse, &SMVCallRequest{Meta: payloadMeta, Payload: obj}
 		case *payload.VCallResult:
-			return currentPulse, &SMVCallResult{Meta: payloadMeta, Payload: obj}
+			return targetPulse, &SMVCallResult{Meta: payloadMeta, Payload: obj}
 		case *payload.VStateRequest:
 			return obj.AsOf, &SMVStateRequest{Meta: payloadMeta, Payload: obj}
 		case *payload.VStateReport:
-			return currentPulse, &SMVStateReport{Meta: payloadMeta, Payload: obj}
+			return targetPulse, &SMVStateReport{Meta: payloadMeta, Payload: obj}
 		case *payload.VDelegatedRequestFinished:
-			return currentPulse, &SMVDelegatedRequestFinished{Meta: payloadMeta, Payload: obj}
+			return targetPulse, &SMVDelegatedRequestFinished{Meta: payloadMeta, Payload: obj}
 		case *payload.VDelegatedCallRequest:
-			return currentPulse, &SMVDelegatedCallRequest{Meta: payloadMeta, Payload: obj}
+			return targetPulse, &SMVDelegatedCallRequest{Meta: payloadMeta, Payload: obj}
 		case *payload.VDelegatedCallResponse:
-			return currentPulse, &SMVDelegatedCallResponse{Meta: payloadMeta, Payload: obj}
+			return targetPulse, &SMVDelegatedCallResponse{Meta: payloadMeta, Payload: obj}
 		default:
 			logger.Warn(errNoHandler{messageTypeID: payloadTypeID, messageType: payloadType})
 			return 0, nil

--- a/ledger-core/virtual/virtual.go
+++ b/ledger-core/virtual/virtual.go
@@ -29,16 +29,24 @@ type DefaultHandlersFactory struct {
 	metaFactory handlers.FactoryMeta
 }
 
-func (f DefaultHandlersFactory) Classify(_ pulse.Number, pr pulse.Range, input conveyor.InputEvent) (pulse.Number, smachine.CreateFunc, error) {
+func (f DefaultHandlersFactory) Classify(pn pulse.Number, pr pulse.Range, input conveyor.InputEvent) (pulse.Number, smachine.CreateFunc, error) {
 	switch event := input.(type) {
 	case *virtualStateMachine.DispatcherMessage:
+		if pr == nil {
+			return 0, nil, throw.E("event is too old", struct {
+				PN pulse.Number
+				InputType interface{} `fmt:"%T"`
+			}{pn, input})
+		}
+
 		return f.metaFactory.Process(event, pr)
 	case *testWalletAPIStateMachine.TestAPICall:
 		return 0, testWalletAPIStateMachine.Handler(event), nil
 	default:
 		panic(throw.E("unknown event type", struct {
+			PN pulse.Number
 			InputType interface{} `fmt:"%T"`
-		}{InputType: input}))
+		}{pn, input}))
 	}
 }
 


### PR DESCRIPTION
**- What I did**
* enable to use pulse.Range for expected (future) pulse data
* look up for pulse.Range in conveyor's cache
* additional checks for missing pulse.Range (event is too old)

