### PR TITLE
PLAT-505: Test: Send VStateReport with Missing state if constructor was interrupted before runner call

### DIFF
--- a/ledger-core/virtual/execute/execute_test.go
+++ b/ledger-core/virtual/execute/execute_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/gojuno/minimock/v3"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
 
 	"github.com/insolar/assured-ledger/ledger-core/application/builtin/proxy/testwallet"
 	"github.com/insolar/assured-ledger/ledger-core/conveyor"
@@ -494,7 +495,10 @@ func TestSMExecute_VCallResultPassedToSMObject(t *testing.T) {
 
 func TestSendVStateReportWithMissingState_IfConstructorWasInterruptedBeforeRunnerCall(t *testing.T) {
 	t.Log("C5084")
-	defer testutils.LeakTester(t)
+	defer testutils.LeakTester(t,
+		goleak.IgnoreTopFunction("github.com/insolar/assured-ledger/ledger-core/runner.(*worker).Run.func1"),
+		goleak.IgnoreTopFunction("github.com/insolar/assured-ledger/ledger-core/conveyor/smachine.startChannelWorkerUnlimParallel.func1"),
+	)
 
 	var (
 		mc  = minimock.NewController(t)

--- a/ledger-core/virtual/execute/execute_test.go
+++ b/ledger-core/virtual/execute/execute_test.go
@@ -8,6 +8,7 @@ package execute
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/gojuno/minimock/v3"
 	"github.com/stretchr/testify/assert"
@@ -27,12 +28,14 @@ import (
 	"github.com/insolar/assured-ledger/ledger-core/runner/execution"
 	"github.com/insolar/assured-ledger/ledger-core/runner/requestresult"
 	"github.com/insolar/assured-ledger/ledger-core/testutils"
+	"github.com/insolar/assured-ledger/ledger-core/testutils/debuglogger"
 	"github.com/insolar/assured-ledger/ledger-core/testutils/gen"
 	"github.com/insolar/assured-ledger/ledger-core/testutils/messagesender"
 	"github.com/insolar/assured-ledger/ledger-core/vanilla/longbits"
 	"github.com/insolar/assured-ledger/ledger-core/virtual/authentication"
 	"github.com/insolar/assured-ledger/ledger-core/virtual/object"
 	"github.com/insolar/assured-ledger/ledger-core/virtual/testutils/shareddata"
+	"github.com/insolar/assured-ledger/ledger-core/virtual/testutils/slotdebugger"
 )
 
 func expectedInitState(ctx context.Context, sm SMExecute) SMExecute {
@@ -487,4 +490,71 @@ func TestSMExecute_VCallResultPassedToSMObject(t *testing.T) {
 	require.NotNil(t, result)
 
 	mc.Finish()
+}
+
+func TestSendVStateReportWithMissingState_IfConstructorWasInterruptedBeforeRunnerCall(t *testing.T) {
+	t.Log("C5084")
+	defer testutils.LeakTester(t)
+
+	var (
+		mc  = minimock.NewController(t)
+		ctx = context.Background()
+
+		class                              = gen.UniqueGlobalRef()
+		caller                             = gen.UniqueGlobalRef()
+		catalog     object.Catalog         = object.NewLocalCatalog()
+		authService authentication.Service = authentication.NewServiceMock(t)
+	)
+
+	slotMachine := slotdebugger.New(ctx, t)
+	slotMachine.PrepareRunner(ctx, mc)
+
+	slotMachine.AddInterfaceDependency(&catalog)
+	slotMachine.AddInterfaceDependency(&authService)
+
+	var vStateReportRecv = make(chan struct{})
+	slotMachine.PrepareMockedMessageSender(mc)
+	slotMachine.MessageSender.SendRole.SetCheckMessage(func(msg payload.Marshaler) {
+		res, ok := msg.(*payload.VStateReport)
+		require.True(t, ok)
+		require.Equal(t, payload.Missing, res.Status)
+		close(vStateReportRecv)
+	})
+
+	outgoing := slotMachine.GenerateLocal()
+
+	smExecute := SMExecute{
+		Payload: &payload.VCallRequest{
+			CallType:     payload.CTConstructor,
+			CallFlags:    payload.BuildCallFlags(contract.CallTolerable, contract.CallDirty),
+			CallOutgoing: outgoing,
+
+			Caller:         caller,
+			Callee:         class,
+			CallSiteMethod: "New",
+		},
+		Meta: &payload.Meta{
+			Sender: caller,
+		},
+	}
+	slotMachine.Start()
+	defer slotMachine.Stop()
+
+	smWrapper := slotMachine.AddStateMachine(ctx, &smExecute)
+	slotMachine.RunTil(smWrapper.BeforeStep(smExecute.stepStartRequestProcessing))
+	slotMachine.Migrate()
+	go slotMachine.RunTil(func(event debuglogger.UpdateEvent) bool {
+		select {
+		case <-vStateReportRecv:
+			return true
+		default:
+			return false
+		}
+	})
+	select {
+	case <-vStateReportRecv:
+	case <-time.After(10 * time.Second):
+		close(vStateReportRecv)
+		t.Error("timeout")
+	}
 }


### PR DESCRIPTION
**- What I did**
New test for check that message VStateReport will be send with state Missing if constructor was interrupted before runner call

**- How I did it**
Add test

**- How to verify it**
Run test

**- Description for the changelog**
