### PR TITLE
PLAT-506: Test VDelegatedRequestFinished send when pulse was changed …

### DIFF
--- a/ledger-core/virtual/integration/utils/server.go
+++ b/ledger-core/virtual/integration/utils/server.go
@@ -269,6 +269,10 @@ func (s *Server) RandomGlobalWithPulse() reference.Global {
 	return gen.UniqueGlobalRefWithPulse(s.GetPulse().PulseNumber)
 }
 
+func (s *Server) DelegationToken(outgoing reference.Global, to reference.Global, object reference.Global) payload.CallDelegationToken {
+	return s.virtual.AuthenticationService.GetCallDelegationToken(outgoing, to, s.GetPulse().PulseNumber, object)
+}
+
 func (s *Server) Stop() {
 	defer close(s.fullStop)
 


### PR DESCRIPTION
Testing this cases:
* send VStateReport{State: Empty, OrderedPendingCount: 1} if constructor was interrupted by migration after outgoing call to runner
* receiving delegation token
* send VCallResult with runner result
* send VStateRequest with pulse from constructor return not changed VStateReport {State: Empty, OrderedPendingCount: 1}

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**

