### PR TITLE
PLAT-397: bad contract method call returns error instead of panic

### DIFF
--- a/ledger-core/virtual/execute/execute.plantuml
+++ b/ledger-core/virtual/execute/execute.plantuml
@@ -69,6 +69,7 @@ T01_U003 --[dashed]> T01_S017
 state "stepFinishRequest" as T01_S027
 T01_S027 : SMExecute
 T01_S027 --[dotted]> T01_S012
+T01_S027 --[dotted]> T01_S001
 T01_S027 --> T01_S025 : [s.migrationHappened]
 T01_S027 --[dashed]> T01_S027 : [smachine.NotPassed]\nWaitShared
 T01_S027 --> [*]
@@ -94,6 +95,7 @@ T01_S004 --> T01_S005
 state "stepIsolationNegotiation" as T01_S006
 T01_S006 : SMExecute
 T01_S006 --[dotted]> T01_S001
+T01_S006 --> T01_S026 : [s.executionNewState!=nil]
 state T01_U005 <<fork>>
 T01_S006 --> T01_U005 : [s.methodIsolation.IsZero()]
 T01_U005 --> T01_S007 : PrepareExecutionClassify(ctx)
@@ -109,11 +111,13 @@ T01_S024 --> T01_S026
 state "stepSendCallResult" as T01_S026
 T01_S026 : SMExecute
 T01_S026 --[dotted]> T01_S012
+T01_S026 --[dotted]> T01_S001
 T01_S026 --> T01_S022 : PrepareAsync(ctx).WithoutAutoWakeUp()
 T01_S026 --> T01_S027
 state "stepSendDelegatedRequestFinished" as T01_S025
 T01_S025 : SMExecute
 T01_S025 --[dotted]> T01_S012
+T01_S025 --[dotted]> T01_S001
 T01_S025 --> T01_S022 : PrepareAsync(ctx).WithoutAutoWakeUp()
 T01_S025 --> [*]
 state "stepSendOutgoing" as T01_S021

--- a/ledger-core/virtual/integration/method_test.go
+++ b/ledger-core/virtual/integration/method_test.go
@@ -71,10 +71,12 @@ func Method_PrepareObject(ctx context.Context, server *utils.Server, state paylo
 
 func TestVirtual_BadMethod_WithExecutor(t *testing.T) {
 	t.Log("C4976")
-	t.Skip("https://insolar.atlassian.net/browse/PLAT-397")
+
+	mc := minimock.NewController(t)
 
 	server, ctx := utils.NewServer(nil, t)
 	defer server.Stop()
+	server.IncrementPulseAndWaitIdle(ctx)
 
 	var (
 		class        = testwallet.GetClass()
@@ -84,6 +86,22 @@ func TestVirtual_BadMethod_WithExecutor(t *testing.T) {
 
 	Method_PrepareObject(ctx, server, payload.Ready, objectGlobal)
 
+	executeDone := server.Journal.WaitStopOf(&execute.SMExecute{}, 1)
+
+	expectedError, err := foundation.MarshalMethodErrorResult(
+		throw.W(throw.E("failed to find contracts method"), "failed to classify method"))
+
+	require.NoError(t, err)
+
+	typedChecker := server.PublisherMock.SetTypedChecker(ctx, mc, server)
+	typedChecker.VCallResult.Set(func(res *payload.VCallResult) bool {
+		assert.Equal(t, res.Callee, objectGlobal)
+		assert.Equal(t, res.CallOutgoing, objectLocal)
+		assert.Equal(t, expectedError, res.ReturnArguments)
+
+		return false // no resend msg
+	})
+
 	{
 		pl := payload.VCallRequest{
 			CallType:            payload.CTMethod,
@@ -92,14 +110,19 @@ func TestVirtual_BadMethod_WithExecutor(t *testing.T) {
 			Callee:              objectGlobal,
 			CallSiteDeclaration: class,
 			CallSiteMethod:      "random",
-			CallOutgoing:        server.RandomLocalWithPulse(),
+			CallOutgoing:        objectLocal,
 			Arguments:           insolar.MustSerialize([]interface{}{}),
 		}
 
 		server.SendPayload(ctx, &pl)
-
-		// TODO fix it after implementation https://insolar.atlassian.net/browse/PLAT-397
 	}
+
+	testutils.WaitSignalsTimed(t, 10*time.Second, executeDone)
+	testutils.WaitSignalsTimed(t, 10*time.Second, server.Journal.WaitAllAsyncCallsDone())
+
+	assert.Equal(t, 1, typedChecker.VCallResult.Count())
+
+	mc.Finish()
 }
 
 func TestVirtual_Method_WithExecutor(t *testing.T) {

--- a/ledger-core/virtual/integration/method_test.go
+++ b/ledger-core/virtual/integration/method_test.go
@@ -82,6 +82,7 @@ func TestVirtual_BadMethod_WithExecutor(t *testing.T) {
 		class        = testwallet.GetClass()
 		objectLocal  = server.RandomLocalWithPulse()
 		objectGlobal = reference.NewSelf(objectLocal)
+		outgoing     = server.RandomLocalWithPulse()
 	)
 
 	Method_PrepareObject(ctx, server, payload.Ready, objectGlobal)
@@ -96,7 +97,7 @@ func TestVirtual_BadMethod_WithExecutor(t *testing.T) {
 	typedChecker := server.PublisherMock.SetTypedChecker(ctx, mc, server)
 	typedChecker.VCallResult.Set(func(res *payload.VCallResult) bool {
 		assert.Equal(t, res.Callee, objectGlobal)
-		assert.Equal(t, res.CallOutgoing, objectLocal)
+		assert.Equal(t, res.CallOutgoing, outgoing)
 		assert.Equal(t, expectedError, res.ReturnArguments)
 
 		return false // no resend msg
@@ -110,7 +111,7 @@ func TestVirtual_BadMethod_WithExecutor(t *testing.T) {
 			Callee:              objectGlobal,
 			CallSiteDeclaration: class,
 			CallSiteMethod:      "random",
-			CallOutgoing:        objectLocal,
+			CallOutgoing:        outgoing,
 			Arguments:           insolar.MustSerialize([]interface{}{}),
 		}
 


### PR DESCRIPTION
**- What I did**
- update C4976 TestVirtual_BadMethod_WithExecutor
- provide VCallResult with a wrapped error instead of panic

