### PR TITLE
PLAT-577: Move SMStateFinalizer to separate step 

### DIFF
--- a/ledger-core/virtual/handlers/vstaterequest.go
+++ b/ledger-core/virtual/handlers/vstaterequest.go
@@ -90,7 +90,7 @@ func (s *SMVStateRequest) stepWait(ctx smachine.ExecutionContext) smachine.State
 }
 
 func (s *SMVStateRequest) stepCheckCatalog(ctx smachine.ExecutionContext) smachine.StateUpdate {
-	reportSharedState, stateFound := finalizedstate.GetSharedStateReport(ctx, s.Payload.Object, s.pulseSlot.PulseData().PulseNumber)
+	reportSharedState, stateFound := finalizedstate.GetSharedStateReport(ctx, s.Payload.Object)
 
 	if !stateFound {
 		return ctx.Jump(s.stepBuildMissing)

--- a/ledger-core/virtual/object/finalizedstate/storage.go
+++ b/ledger-core/virtual/object/finalizedstate/storage.go
@@ -8,7 +8,6 @@ package finalizedstate
 import (
 	"github.com/insolar/assured-ledger/ledger-core/conveyor/smachine"
 	"github.com/insolar/assured-ledger/ledger-core/insolar/payload"
-	"github.com/insolar/assured-ledger/ledger-core/pulse"
 	"github.com/insolar/assured-ledger/ledger-core/reference"
 )
 
@@ -25,18 +24,16 @@ func (v SharedReportAccessor) Prepare(fn func(report payload.VStateReport)) smac
 
 type ReportKey struct {
 	ObjectReference reference.Global
-	Pulse           pulse.Number
 }
 
-func BuildReportKey(object reference.Global, pulse pulse.Number) ReportKey {
+func BuildReportKey(object reference.Global) ReportKey {
 	return ReportKey{
 		ObjectReference: object,
-		Pulse:           pulse,
 	}
 }
 
-func GetSharedStateReport(ctx smachine.InOrderStepContext, object reference.Global, pn pulse.Number) (SharedReportAccessor, bool) {
-	if v := ctx.GetPublishedLink(BuildReportKey(object, pn)); v.IsAssignableTo((*payload.VStateReport)(nil)) {
+func GetSharedStateReport(ctx smachine.InOrderStepContext, object reference.Global) (SharedReportAccessor, bool) {
+	if v := ctx.GetPublishedLink(BuildReportKey(object)); v.IsAssignableTo((*payload.VStateReport)(nil)) {
 		return SharedReportAccessor{v}, true
 	}
 	return SharedReportAccessor{}, false

--- a/ledger-core/virtual/object/object.go
+++ b/ledger-core/virtual/object/object.go
@@ -225,6 +225,7 @@ type SMObject struct {
 	readyToWorkCtl smsync.BoolConditionalLink
 
 	waitGetStateUntil time.Time
+	smFinalizer       *finalizedstate.SMStateFinalizer
 
 	// dependencies
 	messageSender messageSenderAdapter.MessageSender
@@ -270,7 +271,7 @@ func (sm *SMObject) Init(ctx smachine.InitializationContext) smachine.StateUpdat
 
 	sm.initWaitGetStateUntil()
 
-	ctx.SetDefaultMigration(sm.migrate)
+	ctx.SetDefaultMigration(sm.stepMigrate)
 
 	return ctx.Jump(sm.stepGetState)
 }
@@ -398,7 +399,7 @@ func (sm *SMObject) createWaitPendingOrderedSM(ctx smachine.ExecutionContext) {
 	}
 }
 
-func (sm *SMObject) migrate(ctx smachine.MigrationContext) smachine.StateUpdate {
+func (sm *SMObject) stepMigrate(ctx smachine.MigrationContext) smachine.StateUpdate {
 	if sm.GetState() == Unknown {
 		ctx.Log().Trace("SMObject migration happened when object is not ready yet")
 		return ctx.Stop()
@@ -406,18 +407,18 @@ func (sm *SMObject) migrate(ctx smachine.MigrationContext) smachine.StateUpdate 
 
 	ctx.UnpublishAll()
 
-	smf := finalizedstate.SMStateFinalizer{
+	sm.smFinalizer = &finalizedstate.SMStateFinalizer{
 		Reference: sm.Reference,
 	}
 
 	sm.checkPendingCounters(ctx.Log())
-	smf.Report = sm.BuildStateReport()
+	sm.smFinalizer.Report = sm.BuildStateReport()
 	if sm.Descriptor() != nil {
-		smf.Report.ProvidedContent.LatestDirtyState = sm.BuildLatestDirtyState()
+		sm.smFinalizer.Report.ProvidedContent.LatestDirtyState = sm.BuildLatestDirtyState()
 	}
 
-	sdl := ctx.Share(&smf.Report, 0)
-	if !ctx.Publish(finalizedstate.BuildReportKey(sm.Reference, sm.pulseSlot.PulseData().PulseNumber), sdl) {
+	sdl := ctx.Share(&sm.smFinalizer.Report, 0)
+	if !ctx.Publish(finalizedstate.BuildReportKey(sm.Reference), sdl) {
 		ctx.Log().Warn(struct {
 			*log.Msg  `txt:"failed to publish state report"`
 			Reference string
@@ -427,9 +428,10 @@ func (sm *SMObject) migrate(ctx smachine.MigrationContext) smachine.StateUpdate 
 		return ctx.Error(fmt.Errorf("failed to publish state report"))
 	}
 
-	return ctx.Jump(func(ctx smachine.ExecutionContext) smachine.StateUpdate {
-		return ctx.ReplaceWith(&smf)
-	})
+	return ctx.Jump(sm.stepFinalize)
+}
+func (sm *SMObject) stepFinalize(ctx smachine.ExecutionContext) smachine.StateUpdate {
+	return ctx.ReplaceWith(sm.smFinalizer)
 }
 
 type pendingCountersWarnMsg struct {

--- a/ledger-core/virtual/object/object.plantuml
+++ b/ledger-core/virtual/object/object.plantuml
@@ -7,20 +7,15 @@ state "Init" as T00_S002
 T00_S002 : SMObject
 T00_S002 --> [*] : [(...).pulseSlot.State()!=conveyor.Present]
 T00_S002 --> [*] : [!ctx.Publish()]
-T00_S002 --> T00_S005 : Migrate: sm.migrate
-state "migrate" as T00_S010
-T00_S010 : SMObject
-T00_S010 --> [*] : [sm.GetState()==Unknown]
-T00_S010 --[dashed]> [*] : [!ctx.Publish()]\nError
-T00_S010 --> T00_S011
-state "migrate.1" as T00_S011
+T00_S002 --> T00_S005 : Migrate: sm.stepMigrate
+state "sm.messageSender" as T00_S004 <<sdlreceive>>
+state "stepFinalize" as T00_S011
 T00_S011 : SMObject
 T00_S011 --[dotted]> T00_S010
-state "smf" as T00_U001
+state "sm.smFinalizer" as T00_U001
 T00_U001 : SMObject
 T00_U001 : UNKNOWN 
 T00_S011 --[dashed]> T00_U001 : Migrate: <nil>\nReplace
-state "sm.messageSender" as T00_S004 <<sdlreceive>>
 state "stepGetState" as T00_S005
 T00_S005 : SMObject
 T00_S005 --[dotted]> T00_S010
@@ -31,6 +26,11 @@ state "stepGotState" as T00_S007
 T00_S007 : SMObject
 T00_S007 --[dotted]> T00_S010
 T00_S007 --> T00_S008
+state "stepMigrate" as T00_S010
+T00_S010 : SMObject
+T00_S010 --> [*] : [sm.GetState()==Unknown]
+T00_S010 --[dashed]> [*] : [!ctx.Publish()]\nError
+T00_S010 --> T00_S011
 state "stepReadyToWork" as T00_S008
 T00_S008 : SMObject
 T00_S008 --[dotted]> T00_S010

--- a/ledger-core/virtual/object/object_migration_test.go
+++ b/ledger-core/virtual/object/object_migration_test.go
@@ -34,7 +34,7 @@ func TestSMObject_InitSetMigration(t *testing.T) {
 	)
 
 	compareDefaultMigration := func(fn smachine.MigrateFunc) {
-		require.True(t, testutils.CmpStateFuncs(smObject.migrate, fn))
+		require.True(t, testutils.CmpStateFuncs(smObject.stepMigrate, fn))
 	}
 	initCtx := smachine.NewInitializationContextMock(mc).
 		ShareMock.Return(sharedStateData).
@@ -66,12 +66,12 @@ func TestSMObject_MigrationCreateStateReport_IfStateMissing(t *testing.T) {
 		LogMock.Return(smachine.Logger{}).
 		ShareMock.Return(smachine.NewUnboundSharedData(&report)).
 		PublishMock.Set(func(key interface{}, data interface{}) (b1 bool) {
-		assert.Equal(t, finalizedstate.BuildReportKey(report.Object, smObject.pulseSlot.PulseData().PulseNumber), key)
+		assert.Equal(t, finalizedstate.BuildReportKey(report.Object), key)
 		assert.NotNil(t, data)
 		return true
 	})
 
-	smObject.migrate(migrationCtx)
+	smObject.stepMigrate(migrationCtx)
 
 	mc.Finish()
 }
@@ -88,7 +88,7 @@ func TestSMObject_MigrationStop_IfStateUnknown(t *testing.T) {
 		StopMock.Return(smachine.StateUpdate{}).
 		LogMock.Return(smachine.Logger{})
 
-	smObject.migrate(migrationCtx)
+	smObject.stepMigrate(migrationCtx)
 
 	mc.Finish()
 }
@@ -116,14 +116,14 @@ func TestSMObject_MigrationCreateStateReport_IfStateIsEmptyAndNoCounters(t *test
 		}).
 		PublishMock.Set(
 		func(key interface{}, data interface{}) (b1 bool) {
-			refKey := finalizedstate.BuildReportKey(smObject.Reference, smObject.pulseSlot.PulseData().PulseNumber)
+			refKey := finalizedstate.BuildReportKey(smObject.Reference)
 			require.Equal(t, refKey, key)
 			require.Equal(t, sharedData, data)
 			return true
 		}).
 		JumpMock.Return(smachine.StateUpdate{})
 
-	smObject.migrate(migrationCtx)
+	smObject.stepMigrate(migrationCtx)
 
 	mc.Finish()
 }
@@ -148,12 +148,12 @@ func TestSMObject_MigrationCreateStateReport_IfStateEmptyAndCountersSet(t *testi
 		LogMock.Return(smachine.Logger{}).
 		ShareMock.Return(smachine.NewUnboundSharedData(&report)).
 		PublishMock.Set(func(key interface{}, data interface{}) (b1 bool) {
-		assert.Equal(t, finalizedstate.BuildReportKey(report.Object, smObject.pulseSlot.PulseData().PulseNumber), key)
+		assert.Equal(t, finalizedstate.BuildReportKey(report.Object), key)
 		assert.NotNil(t, data)
 		return true
 	})
 
-	smObject.migrate(migrationCtx)
+	smObject.stepMigrate(migrationCtx)
 
 	mc.Finish()
 }


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
-  Move SMStateFinalizer to separate step 
-  rename migrate to stepMigrate 
-  remove pulse number from ReportKey

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
