### PR TITLE
PLAT-555: refactor method tests and added one case 

### DIFF
--- a/ledger-core/virtual/handlers/vdelegatedcallrequest_test.go
+++ b/ledger-core/virtual/handlers/vdelegatedcallrequest_test.go
@@ -186,7 +186,7 @@ func TestSMVDelegatedCallRequest(t *testing.T) {
 			expectedError:                 true,
 		},
 		{
-			name:                          "wrong call interference flag: expected intolerable, get tolerable",
+			name:                          "wrong call interference flag_expected intolerable, get tolerable",
 			testRailCase:                  "C4989",
 			PendingRequestTable:           object.NewRequestTable(),
 			requestRef:                    reference.NewSelf(gen.UniqueLocalRefWithPulse(pulse.OfNow())),
@@ -196,7 +196,7 @@ func TestSMVDelegatedCallRequest(t *testing.T) {
 			expectedError:                 true,
 		},
 		{
-			name:                        "wrong call interference flag: expected tolerable, get intolerable",
+			name:                        "wrong call interference flag_expected tolerable, get intolerable",
 			testRailCase:                "C5128",
 			PendingRequestTable:         object.NewRequestTable(),
 			requestRef:                  reference.NewSelf(gen.UniqueLocalRefWithPulse(pulse.OfNow())),

--- a/ledger-core/virtual/integration/contract_calls_test.go
+++ b/ledger-core/virtual/integration/contract_calls_test.go
@@ -1,0 +1,509 @@
+// Copyright 2020 Insolar Network Ltd.
+// All rights reserved.
+// This material is licensed under the Insolar License version 1.0,
+// available at https://github.com/insolar/assured-ledger/blob/master/LICENSE.md.
+
+package integration
+
+import (
+	"testing"
+	"time"
+
+	"github.com/gojuno/minimock/v3"
+	"github.com/insolar/assured-ledger/ledger-core/insolar/contract"
+	"github.com/insolar/assured-ledger/ledger-core/insolar/payload"
+	"github.com/insolar/assured-ledger/ledger-core/instrumentation/inslogger"
+	"github.com/insolar/assured-ledger/ledger-core/reference"
+	"github.com/insolar/assured-ledger/ledger-core/runner/execution"
+	"github.com/insolar/assured-ledger/ledger-core/runner/requestresult"
+	"github.com/insolar/assured-ledger/ledger-core/testutils/gen"
+	"github.com/insolar/assured-ledger/ledger-core/testutils/runner/logicless"
+	"github.com/insolar/assured-ledger/ledger-core/virtual/execute"
+	"github.com/insolar/assured-ledger/ledger-core/virtual/integration/utils"
+	"github.com/insolar/assured-ledger/ledger-core/virtual/testutils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var byteArguments = []byte("123")
+
+func tolerableFlags() contract.MethodIsolation {
+	return contract.MethodIsolation{
+		Interference: contract.CallTolerable,
+		State:        contract.CallDirty,
+	}
+}
+
+func intolerableFlags() contract.MethodIsolation {
+	return contract.MethodIsolation{
+		Interference: contract.CallIntolerable,
+		State:        contract.CallDirty,
+	}
+}
+
+// for happy path tests
+func assertVCallResult(t *testing.T,
+	res *payload.VCallResult,
+	objectCaller reference.Global,
+	objectCallee reference.Global,
+	flagsCaller contract.MethodIsolation,
+	outgoing reference.Local) {
+
+	require.Equal(t, payload.CTMethod, res.CallType)
+	require.Equal(t, objectCaller, res.Caller)
+	require.Equal(t, objectCallee, res.Callee)
+	require.Equal(t, outgoing.Pulse(), res.CallOutgoing.Pulse())
+	assert.Equal(t, flagsCaller.Interference, res.CallFlags.GetInterference()) // copy from VCallRequest
+	assert.Equal(t, flagsCaller.State, res.CallFlags.GetState())
+}
+
+// for happy path tests
+func assertVCallRequest(t *testing.T,
+	objectCaller reference.Global,
+	objectCallee reference.Global,
+	request *payload.VCallRequest,
+	flagsCaller contract.MethodIsolation) {
+
+	assert.Equal(t, objectCallee, request.Callee)
+	assert.Equal(t, objectCaller, request.Caller)
+	assert.Equal(t, payload.CTMethod, request.CallType)
+	assert.Equal(t, flagsCaller.Interference, request.CallFlags.GetInterference())
+	assert.Equal(t, flagsCaller.State, request.CallFlags.GetState())
+	assert.Equal(t, uint32(1), request.CallSequence)
+
+}
+
+func TestVirtual_CallContractFromContract(t *testing.T) {
+	t.Log("C5086")
+	table := []struct {
+		name   string
+		flagsA contract.MethodIsolation
+		flagsB contract.MethodIsolation
+	}{
+		{
+			name:   "ordered A.Foo calls ordered B.Bar",
+			flagsA: tolerableFlags(),
+			flagsB: tolerableFlags(),
+		}, {
+			name:   "ordered A.Foo calls unordered B.Bar",
+			flagsA: tolerableFlags(),
+			flagsB: intolerableFlags(),
+		},
+		{
+			name:   "unordered A.Foo calls unordered B.Bar",
+			flagsA: intolerableFlags(),
+			flagsB: intolerableFlags(),
+		},
+	}
+	for _, test := range table {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+
+			mc := minimock.NewController(t)
+
+			server, ctx := utils.NewUninitializedServer(nil, t)
+			defer server.Stop()
+			logger := inslogger.FromContext(ctx)
+
+			executeDone := server.Journal.WaitStopOf(&execute.SMExecute{}, 2)
+
+			runnerMock := logicless.NewServiceMock(ctx, mc, func(execution execution.Context) string {
+				return execution.Request.CallSiteMethod
+			})
+			server.ReplaceRunner(runnerMock)
+			server.Init(ctx)
+			server.IncrementPulseAndWaitIdle(ctx)
+
+			var (
+				class = gen.UniqueGlobalRef()
+
+				outgoingA       = server.RandomLocalWithPulse()
+				objectAGlobal   = reference.NewSelf(outgoingA)
+				outgoingCallRef = gen.UniqueGlobalRef()
+				objectBGlobal   = reference.NewSelf(server.RandomLocalWithPulse())
+			)
+
+			typedChecker := server.PublisherMock.SetTypedChecker(ctx, mc, server)
+
+			Method_PrepareObject(ctx, server, payload.Ready, objectAGlobal)
+			Method_PrepareObject(ctx, server, payload.Ready, objectBGlobal)
+
+			// add mock
+			{
+				outgoingCall := execution.NewRPCBuilder(outgoingCallRef, objectAGlobal).CallMethod(objectBGlobal, class, "Bar", byteArguments)
+				objectAExecutionMock := runnerMock.AddExecutionMock("Foo")
+				objectAExecutionMock.AddStart(
+					func(ctx execution.Context) {
+						logger.Debug("ExecutionStart [A.Foo]")
+						require.Equal(t, objectAGlobal, ctx.Request.Callee)
+						require.Equal(t, outgoingA, ctx.Request.CallOutgoing)
+					},
+					&execution.Update{
+						Type:     execution.OutgoingCall,
+						Error:    nil,
+						Outgoing: outgoingCall,
+					},
+				)
+				objectAExecutionMock.AddContinue(
+					func(result []byte) {
+						logger.Debug("ExecutionContinue [A.Foo]")
+						require.Equal(t, []byte("finish B.Bar"), result)
+					},
+					&execution.Update{
+						Type:   execution.Done,
+						Result: requestresult.New([]byte("finish A.Foo"), objectAGlobal),
+					},
+				)
+
+				runnerMock.AddExecutionMock("Bar").AddStart(
+					func(ctx execution.Context) {
+						logger.Debug("ExecutionStart [B.Bar]")
+						require.Equal(t, objectBGlobal, ctx.Request.Callee)
+						require.Equal(t, objectAGlobal, ctx.Request.Caller)
+						require.Equal(t, byteArguments, ctx.Request.Arguments)
+					},
+					&execution.Update{
+						Type:   execution.Done,
+						Result: requestresult.New([]byte("finish B.Bar"), objectBGlobal),
+					},
+				)
+
+				runnerMock.AddExecutionClassify("Foo", test.flagsA, nil)
+				runnerMock.AddExecutionClassify("Bar", test.flagsB, nil)
+			}
+
+			// checks
+			{
+				typedChecker.VCallRequest.Set(func(request *payload.VCallRequest) bool {
+					assertVCallRequest(t, objectAGlobal, objectBGlobal, request, test.flagsA)
+					assert.Equal(t, outgoingCallRef, request.CallReason)
+					assert.Equal(t, server.GetPulse().PulseNumber, request.CallOutgoing.Pulse())
+					return true // resend
+				})
+
+				typedChecker.VCallResult.Set(func(res *payload.VCallResult) bool {
+					switch res.Callee {
+					case objectAGlobal:
+						require.Equal(t, []byte("finish A.Foo"), res.ReturnArguments)
+						assertVCallResult(t, res, server.GlobalCaller(), objectAGlobal, test.flagsA, outgoingA)
+					case objectBGlobal:
+						require.Equal(t, []byte("finish B.Bar"), res.ReturnArguments)
+						assertVCallResult(t, res, objectAGlobal, objectBGlobal, test.flagsA, outgoingA)
+
+					default:
+						t.Fatalf("wrong Callee")
+					}
+					// we should resend that message only if it's CallResult from B to A
+					return res.Caller == objectAGlobal
+				})
+			}
+
+			pl := payload.VCallRequest{
+				CallType:            payload.CTMethod,
+				CallFlags:           payload.BuildCallFlags(test.flagsA.Interference, test.flagsA.State),
+				Caller:              server.GlobalCaller(),
+				Callee:              objectAGlobal,
+				CallSiteDeclaration: class,
+				CallSiteMethod:      "Foo",
+				CallOutgoing:        outgoingA,
+			}
+
+			server.SendPayload(ctx, &pl)
+
+			testutils.WaitSignalsTimed(t, 10*time.Second, executeDone)
+			testutils.WaitSignalsTimed(t, 10*time.Second, server.Journal.WaitAllAsyncCallsDone())
+
+			require.Equal(t, 1, typedChecker.VCallRequest.Count())
+			require.Equal(t, 2, typedChecker.VCallResult.Count())
+
+			mc.Finish()
+		})
+	}
+}
+
+func TestVirtual_CallOtherMethodInObject(t *testing.T) {
+	t.Log("C5116")
+	table := []struct {
+		name        string
+		stateSender contract.MethodIsolation
+	}{
+		{
+			name:        "ordered A.Foo calls unordered A.Bar",
+			stateSender: tolerableFlags(),
+		}, {
+			name:        "unordered A.Foo calls unordered A.Bar",
+			stateSender: intolerableFlags(),
+		},
+	}
+	for _, test := range table {
+		t.Run(test.name, func(t *testing.T) {
+
+			mc := minimock.NewController(t)
+
+			server, ctx := utils.NewUninitializedServer(nil, t)
+			defer server.Stop()
+			executeDone := server.Journal.WaitStopOf(&execute.SMExecute{}, 2)
+
+			logger := inslogger.FromContext(ctx)
+
+			runnerMock := logicless.NewServiceMock(ctx, mc, func(execution execution.Context) string {
+				return execution.Request.CallSiteMethod
+			})
+			server.ReplaceRunner(runnerMock)
+			server.Init(ctx)
+			server.IncrementPulseAndWaitIdle(ctx)
+
+			typedChecker := server.PublisherMock.SetTypedChecker(ctx, mc, server)
+
+			var (
+				class           = gen.UniqueGlobalRef()
+				outgoingA       = server.RandomLocalWithPulse()
+				objectAGlobal   = reference.NewSelf(outgoingA)
+				outgoingCallRef = gen.UniqueGlobalRef()
+			)
+
+			Method_PrepareObject(ctx, server, payload.Ready, objectAGlobal)
+
+			// add mok
+			{
+				outgoingCall := execution.NewRPCBuilder(outgoingCallRef, objectAGlobal).CallMethod(objectAGlobal, class, "Bar", byteArguments)
+				objectAExecutionMock := runnerMock.AddExecutionMock("Foo")
+				objectAExecutionMock.AddStart(
+					func(ctx execution.Context) {
+						logger.Debug("ExecutionStart [A.Foo]")
+						require.Equal(t, objectAGlobal, ctx.Request.Callee)
+						require.Equal(t, outgoingA, ctx.Request.CallOutgoing)
+					},
+					&execution.Update{
+						Type:     execution.OutgoingCall,
+						Error:    nil,
+						Outgoing: outgoingCall,
+					},
+				)
+				objectAExecutionMock.AddContinue(
+					func(result []byte) {
+						logger.Debug("ExecutionContinue [A.Foo]")
+						require.Equal(t, []byte("finish A.Bar"), result)
+					},
+					&execution.Update{
+						Type:   execution.Done,
+						Result: requestresult.New([]byte("finish A.Foo"), objectAGlobal),
+					},
+				)
+
+				runnerMock.AddExecutionMock("Bar").AddStart(
+					func(ctx execution.Context) {
+						logger.Debug("ExecutionStart [A.Bar]")
+						require.Equal(t, objectAGlobal, ctx.Request.Callee)
+						require.Equal(t, objectAGlobal, ctx.Request.Caller)
+						require.Equal(t, byteArguments, ctx.Request.Arguments)
+					},
+					&execution.Update{
+						Type:   execution.Done,
+						Result: requestresult.New([]byte("finish A.Bar"), objectAGlobal),
+					},
+				)
+
+				runnerMock.AddExecutionClassify("Foo", test.stateSender, nil)
+				runnerMock.AddExecutionClassify("Bar", intolerableFlags(), nil)
+			}
+
+			// add typedChecker
+			{
+				typedChecker.VCallRequest.Set(func(request *payload.VCallRequest) bool {
+					assertVCallRequest(t, objectAGlobal, objectAGlobal, request, test.stateSender)
+					assert.Equal(t, outgoingCallRef, request.CallReason)
+					assert.Equal(t, server.GetPulse().PulseNumber, request.CallOutgoing.Pulse())
+					return true // resend
+				})
+
+				typedChecker.VCallResult.Set(func(res *payload.VCallResult) bool {
+					switch res.Caller {
+					case objectAGlobal:
+						require.Equal(t, []byte("finish A.Bar"), res.ReturnArguments)
+						assertVCallResult(t, res, objectAGlobal, objectAGlobal, test.stateSender, outgoingA)
+					default:
+						require.Equal(t, []byte("finish A.Foo"), res.ReturnArguments)
+						assertVCallResult(t, res, server.GlobalCaller(), objectAGlobal, test.stateSender, outgoingA)
+					}
+					// we should resend that message only if it's CallResult from A to A
+					return res.Caller == objectAGlobal
+				})
+			}
+
+			pl := payload.VCallRequest{
+				CallType:            payload.CTMethod,
+				CallFlags:           payload.BuildCallFlags(test.stateSender.Interference, test.stateSender.State),
+				Caller:              server.GlobalCaller(),
+				Callee:              objectAGlobal,
+				CallSiteDeclaration: class,
+				CallSiteMethod:      "Foo",
+				CallOutgoing:        outgoingA,
+			}
+
+			beforeCount := server.PublisherMock.GetCount()
+			server.SendPayload(ctx, &pl)
+			if !server.PublisherMock.WaitCount(beforeCount+3, 10*time.Second) {
+				t.Fatal("failed to wait until all messages returned")
+			}
+
+			testutils.WaitSignalsTimed(t, 10*time.Second, executeDone)
+			testutils.WaitSignalsTimed(t, 10*time.Second, server.Journal.WaitAllAsyncCallsDone())
+
+			require.Equal(t, 1, typedChecker.VCallRequest.Count())
+			require.Equal(t, 2, typedChecker.VCallResult.Count())
+
+			mc.Finish()
+		})
+	}
+}
+
+func TestVirtual_CallMethodFromConstructor(t *testing.T) {
+	t.Log("C5091")
+	table := []struct {
+		name   string
+		stateB contract.MethodIsolation
+	}{
+		{
+			name:   "A.New calls ordered B.Foo",
+			stateB: tolerableFlags(),
+		}, {
+			name:   "A.New calls unordered B.Foo",
+			stateB: intolerableFlags(),
+		},
+	}
+	for _, test := range table {
+		t.Run(test.name, func(t *testing.T) {
+
+			mc := minimock.NewController(t)
+
+			server, ctx := utils.NewUninitializedServer(nil, t)
+			defer server.Stop()
+
+			logger := inslogger.FromContext(ctx)
+
+			executeDone := server.Journal.WaitStopOf(&execute.SMExecute{}, 2)
+
+			runnerMock := logicless.NewServiceMock(ctx, mc, func(execution execution.Context) string {
+				return execution.Request.CallSiteMethod
+			})
+			server.ReplaceRunner(runnerMock)
+			server.Init(ctx)
+			server.IncrementPulseAndWaitIdle(ctx)
+
+			typedChecker := server.PublisherMock.SetTypedChecker(ctx, mc, server)
+
+			var (
+				callFlags = tolerableFlags()
+
+				classA        = gen.UniqueGlobalRef()
+				outgoingA     = server.RandomLocalWithPulse()
+				objectAGlobal = reference.NewSelf(outgoingA)
+
+				classB        = gen.UniqueGlobalRef()
+				objectBGlobal = reference.NewSelf(server.RandomLocalWithPulse())
+
+				outgoingCallRef = gen.UniqueGlobalRef()
+			)
+
+			Method_PrepareObject(ctx, server, payload.Ready, objectBGlobal)
+
+			// add ExecutionMocks to runnerMock
+			{
+				outgoingCall := execution.NewRPCBuilder(outgoingCallRef, objectAGlobal).CallMethod(objectBGlobal, classB, "Foo", byteArguments)
+				objectAResult := requestresult.New([]byte("finish A.New"), objectAGlobal)
+				objectAResult.SetActivate(reference.Global{}, classA, []byte("state A"))
+				objectAExecutionMock := runnerMock.AddExecutionMock("New")
+				objectAExecutionMock.AddStart(
+					func(ctx execution.Context) {
+						logger.Debug("ExecutionStart [A.New]")
+						require.Equal(t, classA, ctx.Request.Callee)
+						require.Equal(t, outgoingA, ctx.Request.CallOutgoing)
+					},
+					&execution.Update{
+						Type:     execution.OutgoingCall,
+						Error:    nil,
+						Outgoing: outgoingCall,
+					},
+				)
+				objectAExecutionMock.AddContinue(
+					func(result []byte) {
+						logger.Debug("ExecutionContinue [A.New]")
+						require.Equal(t, []byte("finish B.Foo"), result)
+					},
+					&execution.Update{
+						Type:   execution.Done,
+						Result: objectAResult,
+					},
+				)
+
+				runnerMock.AddExecutionMock("Foo").AddStart(
+					func(ctx execution.Context) {
+						logger.Debug("ExecutionStart [B.Foo]")
+						require.Equal(t, objectBGlobal, ctx.Request.Callee)
+						require.Equal(t, objectAGlobal, ctx.Request.Caller)
+						require.Equal(t, byteArguments, ctx.Request.Arguments)
+					},
+					&execution.Update{
+						Type:   execution.Done,
+						Result: requestresult.New([]byte("finish B.Foo"), objectBGlobal),
+					},
+				)
+
+				runnerMock.AddExecutionClassify("Foo", test.stateB, nil)
+			}
+
+			// add checks to typedChecker
+			{
+				typedChecker.VCallRequest.Set(func(request *payload.VCallRequest) bool {
+					assertVCallRequest(t, objectAGlobal, objectBGlobal, request, callFlags)
+					assert.Equal(t, outgoingCallRef, request.CallReason)
+					assert.Equal(t, server.GetPulse().PulseNumber, request.CallOutgoing.Pulse())
+					return true // resend
+				})
+				typedChecker.VCallResult.Set(func(res *payload.VCallResult) bool {
+					assert.Equal(t, callFlags.State, res.CallFlags.GetState())
+					assert.Equal(t, callFlags.Interference, res.CallFlags.GetInterference())
+
+					switch res.Callee {
+					case objectAGlobal:
+						require.Equal(t, []byte("finish A.New"), res.ReturnArguments)
+						require.Equal(t, payload.CTConstructor, res.CallType)
+						require.Equal(t, server.GlobalCaller(), res.Caller)
+						require.Equal(t, outgoingA, res.CallOutgoing)
+					case objectBGlobal:
+						require.Equal(t, []byte("finish B.Foo"), res.ReturnArguments)
+						require.Equal(t, payload.CTMethod, res.CallType)
+						require.Equal(t, objectAGlobal, res.Caller)
+						require.Equal(t, server.GetPulse().PulseNumber, res.CallOutgoing.Pulse())
+
+					default:
+						t.Fatalf("wrong Callee")
+					}
+					// we should resend that message only if it's CallResult from B to A
+					return res.Caller == objectAGlobal
+				})
+			}
+
+			pl := payload.VCallRequest{
+				CallType:       payload.CTConstructor,
+				CallFlags:      payload.BuildCallFlags(callFlags.Interference, callFlags.State),
+				Caller:         server.GlobalCaller(),
+				Callee:         classA,
+				CallSiteMethod: "New",
+				CallOutgoing:   outgoingA,
+			}
+			msg := server.WrapPayload(&pl).Finalize()
+			server.SendMessage(ctx, msg)
+
+			// wait for all calls and SMs
+			testutils.WaitSignalsTimed(t, 10*time.Second, executeDone)
+			testutils.WaitSignalsTimed(t, 10*time.Second, server.Journal.WaitAllAsyncCallsDone())
+
+			require.Equal(t, 1, typedChecker.VCallRequest.Count())
+			require.Equal(t, 2, typedChecker.VCallResult.Count())
+
+			mc.Finish()
+		})
+	}
+}

--- a/ledger-core/virtual/integration/contract_calls_test.go
+++ b/ledger-core/virtual/integration/contract_calls_test.go
@@ -343,11 +343,7 @@ func TestVirtual_CallOtherMethodInObject(t *testing.T) {
 				CallOutgoing:        outgoingA,
 			}
 
-			beforeCount := server.PublisherMock.GetCount()
 			server.SendPayload(ctx, &pl)
-			if !server.PublisherMock.WaitCount(beforeCount+3, 10*time.Second) {
-				t.Fatal("failed to wait until all messages returned")
-			}
 
 			testutils.WaitSignalsTimed(t, 10*time.Second, executeDone)
 			testutils.WaitSignalsTimed(t, 10*time.Second, server.Journal.WaitAllAsyncCallsDone())

--- a/ledger-core/virtual/integration/contract_calls_test.go
+++ b/ledger-core/virtual/integration/contract_calls_test.go
@@ -176,6 +176,7 @@ func TestVirtual_CallContractFromContract(t *testing.T) {
 			{
 				typedChecker.VCallRequest.Set(func(request *payload.VCallRequest) bool {
 					assertVCallRequest(t, objectAGlobal, objectBGlobal, request, test.flagsA)
+					assert.Equal(t, byteArguments, request.Arguments)
 					assert.Equal(t, outgoingCallRef, request.CallReason)
 					assert.Equal(t, server.GetPulse().PulseNumber, request.CallOutgoing.Pulse())
 					return true // resend
@@ -312,6 +313,7 @@ func TestVirtual_CallOtherMethodInObject(t *testing.T) {
 			{
 				typedChecker.VCallRequest.Set(func(request *payload.VCallRequest) bool {
 					assertVCallRequest(t, objectAGlobal, objectAGlobal, request, test.stateSender)
+					assert.Equal(t, byteArguments, request.Arguments)
 					assert.Equal(t, outgoingCallRef, request.CallReason)
 					assert.Equal(t, server.GetPulse().PulseNumber, request.CallOutgoing.Pulse())
 					return true // resend

--- a/ledger-core/virtual/integration/delegated_finished_test.go
+++ b/ledger-core/virtual/integration/delegated_finished_test.go
@@ -253,7 +253,7 @@ func TestVirtual_SendDelegatedFinished_IfPulseChanged_Without_SideEffect(t *test
 
 func TestVirtual_SendDelegatedFinished_IfPulseChanged_Constructor(t *testing.T) {
 	t.Log("C4988")
-	t.Skip("skipped until PLAT-304")
+	t.Skip("https://insolar.atlassian.net/browse/PLAT-304")
 
 	server, ctx := utils.NewServer(nil, t)
 	defer server.Stop()

--- a/ledger-core/virtual/integration/method_test.go
+++ b/ledger-core/virtual/integration/method_test.go
@@ -70,14 +70,14 @@ func Method_PrepareObject(ctx context.Context, server *utils.Server, state paylo
 	server.WaitActiveThenIdleConveyor()
 }
 
-func tolerableState() contract.MethodIsolation {
+func tolerableFlags() contract.MethodIsolation {
 	return contract.MethodIsolation{
 		Interference: contract.CallTolerable,
 		State:        contract.CallDirty,
 	}
 }
 
-func intolerableState() contract.MethodIsolation {
+func intolerableFlags() contract.MethodIsolation {
 	return contract.MethodIsolation{
 		Interference: contract.CallIntolerable,
 		State:        contract.CallDirty,
@@ -364,20 +364,30 @@ func TestVirtual_CallMethodAfterPulseChange(t *testing.T) {
 
 // ordered A.Foo calls ordered B.Bar
 // ordered A.Foo calls unordered B.Bar
+// unordered A.Foo calls unordered B.Bar
 func TestVirtual_CallContractFromContract_Ordered(t *testing.T) {
 	table := []struct {
 		name   string
 		caseId string
-		stateB contract.MethodIsolation
+		flagsA contract.MethodIsolation
+		flagsB contract.MethodIsolation
 	}{
 		{
 			name:   "ordered A.Foo calls ordered B.Bar",
 			caseId: "C5086",
-			stateB: tolerableState(),
+			flagsA: tolerableFlags(),
+			flagsB: tolerableFlags(),
 		}, {
 			name:   "ordered A.Foo calls unordered B.Bar",
 			caseId: "C5087",
-			stateB: intolerableState(),
+			flagsA: tolerableFlags(),
+			flagsB: intolerableFlags(),
+		},
+		{
+			name:   "unordered A.Foo calls unordered B.Bar",
+			caseId: "C5140",
+			flagsA: intolerableFlags(),
+			flagsB: intolerableFlags(),
 		},
 	}
 	for _, test := range table {
@@ -441,8 +451,8 @@ func TestVirtual_CallContractFromContract_Ordered(t *testing.T) {
 				},
 			)
 
-			runnerMock.AddExecutionClassify("Foo", tolerableState(), nil)
-			runnerMock.AddExecutionClassify("Bar", test.stateB, nil)
+			runnerMock.AddExecutionClassify("Foo", test.flagsA, nil)
+			runnerMock.AddExecutionClassify("Bar", test.flagsB, nil)
 
 			typedChecker := server.PublisherMock.SetTypedChecker(ctx, mc, server)
 			typedChecker.VCallRequest.SetResend(true).ExpectedCount(1)
@@ -459,7 +469,7 @@ func TestVirtual_CallContractFromContract_Ordered(t *testing.T) {
 
 			pl := payload.VCallRequest{
 				CallType:            payload.CTMethod,
-				CallFlags:           payload.BuildCallFlags(contract.CallTolerable, contract.CallDirty),
+				CallFlags:           payload.BuildCallFlags(test.flagsA.Interference, test.flagsA.State),
 				Caller:              server.GlobalCaller(),
 				Callee:              objectAGlobal,
 				CallSiteDeclaration: class,
@@ -491,11 +501,11 @@ func TestVirtual_Call_UnorderedMethod_From_OrderedMethod(t *testing.T) {
 		{
 			name:        "ordered A.Foo calls unordered A.Bar",
 			caseId:      "C5116",
-			stateSender: tolerableState(),
+			stateSender: tolerableFlags(),
 		}, {
 			name:        "unordered A.Foo calls unordered A.Bar",
 			caseId:      "C5122",
-			stateSender: intolerableState(),
+			stateSender: intolerableFlags(),
 		},
 	}
 	for _, test := range table {
@@ -556,7 +566,7 @@ func TestVirtual_Call_UnorderedMethod_From_OrderedMethod(t *testing.T) {
 			)
 
 			runnerMock.AddExecutionClassify("Foo", test.stateSender, nil)
-			runnerMock.AddExecutionClassify("Bar", intolerableState(), nil)
+			runnerMock.AddExecutionClassify("Bar", intolerableFlags(), nil)
 
 			typedChecker := server.PublisherMock.SetTypedChecker(ctx, mc, server)
 			typedChecker.VCallRequest.SetResend(true).ExpectedCount(1)
@@ -595,6 +605,7 @@ func TestVirtual_Call_UnorderedMethod_From_OrderedMethod(t *testing.T) {
 }
 
 // A.New calls ordered B.Foo
+// A.New calls unordered B.Foo
 func TestVirtual_CallMethodFromConstructor_Ordered(t *testing.T) {
 	table := []struct {
 		name   string
@@ -604,11 +615,11 @@ func TestVirtual_CallMethodFromConstructor_Ordered(t *testing.T) {
 		{
 			name:   "A.New calls ordered B.Foo",
 			caseId: "C5091",
-			stateB: tolerableState(),
+			stateB: tolerableFlags(),
 		}, {
 			name:   "A.New calls unordered B.Foo",
 			caseId: "C5092",
-			stateB: intolerableState(),
+			stateB: intolerableFlags(),
 		},
 	}
 	for _, test := range table {

--- a/ledger-core/virtual/integration/method_test.go
+++ b/ledger-core/virtual/integration/method_test.go
@@ -391,6 +391,7 @@ func TestVirtual_CallContractFromContract_Ordered(t *testing.T) {
 		},
 	}
 	for _, test := range table {
+		test := test
 		t.Run(test.name, func(t *testing.T) {
 			t.Log(test.caseId)
 
@@ -399,6 +400,8 @@ func TestVirtual_CallContractFromContract_Ordered(t *testing.T) {
 			server, ctx := utils.NewUninitializedServer(nil, t)
 			defer server.Stop()
 			logger := inslogger.FromContext(ctx)
+
+			executeDone := server.Journal.WaitStopOf(&execute.SMExecute{}, 2)
 
 			runnerMock := logicless.NewServiceMock(ctx, mc, func(execution execution.Context) string {
 				return execution.Request.CallSiteMethod
@@ -417,6 +420,7 @@ func TestVirtual_CallContractFromContract_Ordered(t *testing.T) {
 			Method_PrepareObject(ctx, server, payload.Ready, objectAGlobal)
 			Method_PrepareObject(ctx, server, payload.Ready, objectBGlobal)
 
+			// add mock
 			outgoingCall := execution.NewRPCBuilder(gen.UniqueGlobalRef(), objectAGlobal).CallMethod(objectBGlobal, class, "Bar", []byte{})
 			objectAExecutionMock := runnerMock.AddExecutionMock("Foo")
 			objectAExecutionMock.AddStart(
@@ -454,14 +458,33 @@ func TestVirtual_CallContractFromContract_Ordered(t *testing.T) {
 			runnerMock.AddExecutionClassify("Foo", test.flagsA, nil)
 			runnerMock.AddExecutionClassify("Bar", test.flagsB, nil)
 
+			// checks
 			typedChecker := server.PublisherMock.SetTypedChecker(ctx, mc, server)
-			typedChecker.VCallRequest.SetResend(true).ExpectedCount(1)
+			typedChecker.VCallRequest.Set(func(request *payload.VCallRequest) bool {
+				assert.Equal(t, objectBGlobal, request.Callee)
+				assert.Equal(t, objectAGlobal, request.Caller)
+				assert.Equal(t, payload.CTMethod, request.CallType)
+				assert.Equal(t, uint32(1), request.CallSequence)
+				assert.Equal(t, server.GetPulse().PulseNumber, request.CallOutgoing.Pulse())
+				return true // resend
+			})
+
 			typedChecker.VCallResult.Set(func(res *payload.VCallResult) bool {
 				switch res.Callee {
 				case objectAGlobal:
 					require.Equal(t, []byte("finish A.Foo"), res.ReturnArguments)
+					require.Equal(t, payload.CTMethod, res.CallType)
+					require.Equal(t, server.GlobalCaller(), res.Caller)
+					assert.Equal(t, test.flagsA.Interference, res.CallFlags.GetInterference())
+					assert.Equal(t, test.flagsA.State, res.CallFlags.GetState())
 				case objectBGlobal:
 					require.Equal(t, []byte("finish B.Bar"), res.ReturnArguments)
+					require.Equal(t, payload.CTMethod, res.CallType)
+					require.Equal(t, objectAGlobal, res.Caller)
+					assert.Equal(t, test.flagsB.Interference, res.CallFlags.GetInterference())
+					assert.Equal(t, test.flagsB.State, res.CallFlags.GetState())
+				default:
+					t.Fatalf("wrong Callee")
 				}
 				// we should resend that message only if it's CallResult from B to A
 				return res.Caller == objectAGlobal
@@ -484,7 +507,9 @@ func TestVirtual_CallContractFromContract_Ordered(t *testing.T) {
 				t.Fatal("failed to wait until all messages returned")
 			}
 
-			server.WaitActiveThenIdleConveyor()
+			testutils.WaitSignalsTimed(t, 10*time.Second, executeDone)
+			testutils.WaitSignalsTimed(t, 10*time.Second, server.Journal.WaitAllAsyncCallsDone())
+
 			mc.Finish()
 		})
 	}
@@ -767,6 +792,7 @@ func TestVirtual_CallMethodFromConstructor_Ordered(t *testing.T) {
 // unordered A.Foo sends ordered outgoing and receives error, call method
 // unordered A.Foo sends ordered outgoing and receives error, call constructor
 func TestVirtual_CallContractFromContract_InterferenceViolation(t *testing.T) {
+	t.Log("C4980")
 	table := []struct {
 		name         string
 		caseId       string
@@ -774,17 +800,14 @@ func TestVirtual_CallContractFromContract_InterferenceViolation(t *testing.T) {
 	}{
 		{
 			name:         "unordered A.Foo sends ordered outgoing and receives error, call method",
-			caseId:       "C4980",
 			outgoingCall: "method",
 		}, {
 			name:         "unordered A.Foo sends ordered outgoing and receives error, call constructor",
-			caseId:       "C5203",
 			outgoingCall: "constructor",
 		},
 	}
 	for _, test := range table {
 		t.Run(test.name, func(t *testing.T) {
-			t.Log(test.caseId)
 
 			mc := minimock.NewController(t)
 

--- a/ledger-core/virtual/integration/vdelegated_test.go
+++ b/ledger-core/virtual/integration/vdelegated_test.go
@@ -95,7 +95,7 @@ func TestVirtual_VDelegatedCallRequest(t *testing.T) {
 
 func TestVirtual_VDelegatedCallRequest_GetBalance(t *testing.T) {
 	t.Log("C4982")
-	t.Skip("PLAT-449")
+	t.Skip("https://insolar.atlassian.net/browse/PLAT-449")
 	// flaky test, need to think about how to do it better, maybe move to half-integration
 
 	server, ctx := utils.NewServer(nil, t)


### PR DESCRIPTION
**- What I did**
- fix syntax t.Skip for valid integation testrail with jira
- refactor tests to table
- add test for call unordered B from unordered A
- refactor cases in testrail https://insolar.testrail.io/index.php?/suites/view/78&group_by=cases:section_id&group_order=asc
- move happy-path tests in contract_calls_test.go


