### PR TITLE
PLAT-580: Split request/result in working_table.go

### DIFF
--- a/ledger-core/virtual/execute/execute.go
+++ b/ledger-core/virtual/execute/execute.go
@@ -408,10 +408,7 @@ func (s *SMExecute) stepStartRequestProcessing(ctx smachine.ExecutionContext) sm
 		objectDescriptor descriptor.Object
 	)
 	action := func(state *object.SharedState) {
-		reqRef := s.execution.Outgoing
-
-		reqList := state.KnownRequests.GetList(s.execution.Isolation.Interference)
-		if !reqList.SetActive(reqRef) {
+		if !state.KnownRequests.SetActive(s.execution.Isolation.Interference, s.execution.Outgoing) {
 			// if we come here then request should be in RequestStarted
 			// if it is not it is either somehow lost or it is already processing
 			panic(throw.Impossible())

--- a/ledger-core/virtual/execute/execute.go
+++ b/ledger-core/virtual/execute/execute.go
@@ -315,23 +315,9 @@ func (s *SMExecute) stepDeduplicate(ctx smachine.ExecutionContext) smachine.Stat
 	duplicate := false
 
 	action := func(state *object.SharedState) {
-		req := s.execution.Outgoing
-
-		workingList := state.KnownRequests.GetList(s.execution.Isolation.Interference)
-
-		requestState := workingList.GetState(req)
-		switch requestState {
-		// processing started but not yet processing
-		case object.RequestStarted:
+		if !state.KnownRequests.Add(s.execution.Isolation.Interference, s.execution.Outgoing) {
 			duplicate = true
-			return
-		case object.RequestProcessing:
-			duplicate = true
-			// TODO: we may have result already, should resend
-			return
 		}
-
-		workingList.Add(req)
 	}
 
 	switch s.objectSharedState.Prepare(action).TryUse(ctx).GetDecision() {

--- a/ledger-core/virtual/execute/execute_test.go
+++ b/ledger-core/virtual/execute/execute_test.go
@@ -485,7 +485,7 @@ func TestSMExecute_VCallResultPassedToSMObject(t *testing.T) {
 
 	require.Equal(t, 1, res.Count())
 
-	result, ok := res.GetResult(ref)
+	result, ok := smObject.KnownRequests.GetResults()[ref]
 
 	require.True(t, ok)
 	require.NotNil(t, result)

--- a/ledger-core/virtual/execute/execute_test.go
+++ b/ledger-core/virtual/execute/execute_test.go
@@ -463,7 +463,8 @@ func TestSMExecute_VCallResultPassedToSMObject(t *testing.T) {
 
 	smExecute = expectedInitState(ctx, smExecute)
 
-	smObject.KnownRequests.GetList(contract.CallTolerable).Add(ref)
+	smObject.KnownRequests.Add(contract.CallTolerable, ref)
+	smObject.KnownRequests.SetActive(contract.CallTolerable, ref)
 
 	{
 		execCtx := smachine.NewExecutionContextMock(mc).

--- a/ledger-core/virtual/object/object.go
+++ b/ledger-core/virtual/object/object.go
@@ -123,7 +123,7 @@ func (i *Info) FinishRequest(
 	default:
 		panic(throw.Unsupported())
 	}
-	i.KnownRequests.GetList(isolation.Interference).Finish(requestRef, result)
+	i.KnownRequests.Finish(isolation.Interference, requestRef, result)
 }
 
 func (i *Info) SetDescriptor(objectDescriptor descriptor.Object) {

--- a/ledger-core/virtual/object/working_table.go
+++ b/ledger-core/virtual/object/working_table.go
@@ -28,6 +28,8 @@ func NewWorkingTable() WorkingTable {
 
 	rt.requests = lists
 
+	rt.results = make(map[reference.Global]Summary)
+
 	return rt
 }
 
@@ -62,11 +64,11 @@ func (wt *WorkingTable) Finish(
 	result *payload.VCallResult,
 ) bool {
 	if ok := wt.GetList(flag).Finish(ref); ok {
-		summary, ok := wt.results[ref]
+		_, ok := wt.results[ref]
 		if !ok {
 			panic(throw.IllegalState())
 		}
-		summary.result = result
+		wt.results[ref] = Summary{result: result}
 
 		return true
 	}
@@ -158,7 +160,7 @@ func (rl *WorkingList) calculateEarliestActivePulse() {
 
 func (rl *WorkingList) Finish(ref reference.Global) bool {
 	state := rl.GetState(ref)
-	if state == RequestUnknown {
+	if state == RequestUnknown || state == RequestFinished {
 		return false
 	}
 

--- a/ledger-core/virtual/object/working_table.go
+++ b/ledger-core/virtual/object/working_table.go
@@ -78,7 +78,7 @@ func (wt *WorkingTable) Finish(
 
 func (wt *WorkingTable) Len() int {
 	size := 0
-	for _, list := range wt.requests {
+	for _, list := range wt.requests[1:] {
 		size += list.Count()
 	}
 	return size

--- a/ledger-core/virtual/object/working_table_test.go
+++ b/ledger-core/virtual/object/working_table_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/insolar/assured-ledger/ledger-core/insolar/contract"
-	"github.com/insolar/assured-ledger/ledger-core/insolar/payload"
 	"github.com/insolar/assured-ledger/ledger-core/pulse"
 	"github.com/insolar/assured-ledger/ledger-core/reference"
 	"github.com/insolar/assured-ledger/ledger-core/testutils/gen"
@@ -101,21 +100,13 @@ func TestWorkingList(t *testing.T) {
 	assert.Equal(t, 0, rl.CountFinish())
 	assert.Equal(t, 3, rl.CountActive())
 
-	expResult := payload.VCallResult{
-		Caller: gen.UniqueGlobalRef(),
-		Callee: gen.UniqueGlobalRef(),
-	}
-
-	rl.Finish(RefOne, &expResult)
+	rl.Finish(RefOne)
 	assert.Equal(t, pd.PulseNumber, rl.EarliestPulse()) // doesn't change
 	assert.Equal(t, 1, rl.CountFinish())
 	assert.Equal(t, 2, rl.CountActive())
-	actResult, ok := rl.GetResult(RefOne)
-	assert.True(t, ok)
-	assert.Equal(t, &expResult, actResult)
 
 	// try to finish ref that not in list
-	successFinish := rl.Finish(reference.NewSelf(gen.UniqueLocalRefWithPulse(currentPulse)), nil)
+	successFinish := rl.Finish(reference.NewSelf(gen.UniqueLocalRefWithPulse(currentPulse)))
 	assert.Equal(t, false, successFinish)
 	assert.Equal(t, 1, rl.CountFinish())
 	assert.Equal(t, 2, rl.CountActive())
@@ -151,17 +142,9 @@ func TestWorkingList_Finish(t *testing.T) {
 	assert.Equal(t, 0, rl.CountFinish())
 	assert.Equal(t, 2, rl.CountActive())
 
-	result := payload.VCallResult{
-		Caller: gen.UniqueGlobalRef(),
-		Callee: gen.UniqueGlobalRef(),
-	}
-
-	rl.Finish(RefOne, &result)
+	rl.Finish(RefOne)
 
 	assert.Equal(t, 1, rl.CountFinish())
 	assert.Equal(t, 1, rl.CountActive())
 	assert.Equal(t, nextPulseNumber, rl.earliestActivePulse)
-	actResult, ok := rl.GetResult(RefOne)
-	assert.True(t, ok)
-	assert.Equal(t, &result, actResult)
 }

--- a/ledger-core/virtual/object/working_table_test.go
+++ b/ledger-core/virtual/object/working_table_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/insolar/assured-ledger/ledger-core/insolar/contract"
+	"github.com/insolar/assured-ledger/ledger-core/insolar/payload"
 	"github.com/insolar/assured-ledger/ledger-core/pulse"
 	"github.com/insolar/assured-ledger/ledger-core/reference"
 	"github.com/insolar/assured-ledger/ledger-core/testutils/gen"
@@ -18,13 +19,13 @@ import (
 )
 
 func TestWorkingTable(t *testing.T) {
-	rt := NewWorkingTable()
+	wt := NewWorkingTable()
 
-	assert.Equal(t, 0, rt.GetList(contract.CallIntolerable).Count())
-	assert.Equal(t, 0, len(rt.GetList(contract.CallTolerable).requests))
+	assert.Equal(t, 0, wt.GetList(contract.CallIntolerable).Count())
+	assert.Equal(t, 0, len(wt.GetList(contract.CallTolerable).requests))
 
-	assert.Equal(t, pulse.Number(0), rt.GetList(contract.CallIntolerable).earliestActivePulse)
-	assert.Equal(t, pulse.Number(0), rt.GetList(contract.CallTolerable).earliestActivePulse)
+	assert.Equal(t, pulse.Number(0), wt.GetList(contract.CallIntolerable).earliestActivePulse)
+	assert.Equal(t, pulse.Number(0), wt.GetList(contract.CallTolerable).earliestActivePulse)
 
 	pd := pulse.NewFirstPulsarData(10, longbits.Bits256{})
 	currentPulse := pd.PulseNumber
@@ -32,18 +33,39 @@ func TestWorkingTable(t *testing.T) {
 	object := gen.UniqueLocalRefWithPulse(currentPulse)
 	ref := reference.NewSelf(object)
 
-	intolerableList := rt.GetList(contract.CallIntolerable)
+	intolerableList := wt.GetList(contract.CallIntolerable)
 	assert.True(t, intolerableList.Add(ref))
 
-	assert.Equal(t, 1, rt.GetList(contract.CallIntolerable).Count())
-	assert.Equal(t, 0, rt.GetList(contract.CallTolerable).Count())
-	assert.Equal(t, pulse.Unknown, rt.GetList(contract.CallIntolerable).EarliestPulse())
+	assert.Equal(t, 1, wt.GetList(contract.CallIntolerable).Count())
+	assert.Equal(t, 0, wt.GetList(contract.CallTolerable).Count())
+	assert.Equal(t, pulse.Unknown, wt.GetList(contract.CallIntolerable).EarliestPulse())
 
 	assert.True(t, intolerableList.SetActive(ref))
 
-	assert.Equal(t, 1, rt.GetList(contract.CallIntolerable).Count())
-	assert.Equal(t, 0, rt.GetList(contract.CallTolerable).Count())
-	assert.Equal(t, currentPulse, rt.GetList(contract.CallIntolerable).EarliestPulse())
+	assert.Equal(t, 1, wt.GetList(contract.CallIntolerable).Count())
+	assert.Equal(t, 0, wt.GetList(contract.CallTolerable).Count())
+	assert.Equal(t, currentPulse, wt.GetList(contract.CallIntolerable).EarliestPulse())
+
+	assert.True(t, wt.Add(contract.CallTolerable, ref))
+	assert.False(t, wt.Add(contract.CallTolerable, ref))
+
+	assert.True(t, wt.SetActive(contract.CallTolerable, ref))
+	assert.False(t, wt.SetActive(contract.CallTolerable, ref))
+	assert.False(t, wt.SetActive(contract.CallTolerable, gen.UniqueGlobalRef()))
+
+	res := &payload.VCallResult{
+		Callee: gen.UniqueGlobalRef(),
+	}
+
+	assert.True(t, wt.Finish(contract.CallTolerable, ref, res))
+	assert.False(t, wt.Finish(contract.CallTolerable, ref, res))
+
+	results := wt.GetResults()
+
+	summary, ok := results[ref]
+	assert.True(t, ok)
+	assert.NotNil(t, summary.result)
+	assert.Equal(t, res.Callee, summary.result.Callee)
 }
 
 func TestWorkingList(t *testing.T) {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Split request/result in working_table.go, now result stored in a separate map[reference.Global]Summary

**- How I did it**

**- How to verify it**
working_table_test.go modified

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

https://insolar.atlassian.net/browse/PLAT-580
