### PR TITLE
NOISSUE: sync pending table realization with working table

### DIFF
--- a/ledger-core/virtual/execute/execute_test.go
+++ b/ledger-core/virtual/execute/execute_test.go
@@ -142,7 +142,7 @@ func TestSMExecute_StartRequestProcessing(t *testing.T) {
 
 	smExecute = expectedInitState(ctx, smExecute)
 
-	smObject.SharedState.Info.KnownRequests.GetList(callFlags.GetInterference()).Add(smExecute.execution.Outgoing)
+	smObject.SharedState.Info.KnownRequests.Add(callFlags.GetInterference(), smExecute.execution.Outgoing)
 
 	assert.Equal(t, uint8(0), smObject.PotentialOrderedPendingCount)
 	assert.Equal(t, uint8(0), smObject.PotentialUnorderedPendingCount)

--- a/ledger-core/virtual/object/info_test.go
+++ b/ledger-core/virtual/object/info_test.go
@@ -48,8 +48,8 @@ func TestInfo_GetEarliestPulse(t *testing.T) {
 			getKnownRequests: func() WorkingTable {
 				table := NewWorkingTable()
 				ref := reference.NewSelf(gen.UniqueLocalRefWithPulse(currentPulse))
-				table.GetList(tolerance).Add(ref)
-				table.GetList(tolerance).SetActive(ref)
+				table.GetList(tolerance).add(ref)
+				table.GetList(tolerance).setActive(ref)
 				return table
 			},
 			ExpectedEarliestPulse: currentPulse,
@@ -65,8 +65,8 @@ func TestInfo_GetEarliestPulse(t *testing.T) {
 			getKnownRequests: func() WorkingTable {
 				table := NewWorkingTable()
 				ref := reference.NewSelf(gen.UniqueLocalRefWithPulse(prevPulse))
-				table.GetList(tolerance).Add(ref)
-				table.GetList(tolerance).SetActive(ref)
+				table.GetList(tolerance).add(ref)
+				table.GetList(tolerance).setActive(ref)
 				return table
 			},
 			ExpectedEarliestPulse: prevPulse,

--- a/ledger-core/virtual/object/request_table.go
+++ b/ledger-core/virtual/object/request_table.go
@@ -13,20 +13,22 @@ import (
 )
 
 type PendingTable struct {
-	lists map[contract.InterferenceFlag]*PendingList
+	lists []*PendingList
 }
 
 func NewRequestTable() PendingTable {
 	var rt PendingTable
-	rt.lists = make(map[contract.InterferenceFlag]*PendingList)
 
-	rt.lists[contract.CallTolerable] = NewRequestList()
-	rt.lists[contract.CallIntolerable] = NewRequestList()
+	rt.lists = make([]*PendingList, contract.InterferenceFlagCount)
+	for i := 1; i < contract.InterferenceFlagCount; i++ {
+		rt.lists[i] = NewRequestList()
+	}
+
 	return rt
 }
 
 func (rt *PendingTable) GetList(flag contract.InterferenceFlag) *PendingList {
-	if flag.IsZero() {
+	if flag.IsZero() || flag >= contract.InterferenceFlagCount {
 		panic(throw.IllegalValue())
 	}
 	return rt.lists[flag]

--- a/ledger-core/virtual/object/request_table.go
+++ b/ledger-core/virtual/object/request_table.go
@@ -13,13 +13,12 @@ import (
 )
 
 type PendingTable struct {
-	lists []*PendingList
+	lists [3]*PendingList
 }
 
 func NewRequestTable() PendingTable {
 	var rt PendingTable
 
-	rt.lists = make([]*PendingList, contract.InterferenceFlagCount)
 	for i := 1; i < contract.InterferenceFlagCount; i++ {
 		rt.lists[i] = NewRequestList()
 	}

--- a/ledger-core/virtual/object/request_table.go
+++ b/ledger-core/virtual/object/request_table.go
@@ -13,27 +13,27 @@ import (
 )
 
 type PendingTable struct {
-	lists [3]*PendingList
+	lists [contract.InterferenceFlagCount - 1]*PendingList
 }
 
 func NewRequestTable() PendingTable {
 	var rt PendingTable
 
-	for i := 1; i < contract.InterferenceFlagCount; i++ {
-		rt.lists[i] = NewRequestList()
+	for i := len(rt.lists) - 1; i >= 0; i-- {
+		rt.lists[i] = newRequestList()
 	}
 
 	return rt
 }
 
-func (rt *PendingTable) GetList(flag contract.InterferenceFlag) *PendingList {
-	if flag.IsZero() || flag >= contract.InterferenceFlagCount {
-		panic(throw.IllegalValue())
+func (rt PendingTable) GetList(flag contract.InterferenceFlag) *PendingList {
+	if flag > 0 && int(flag) <= len(rt.lists) {
+		return rt.lists[flag - 1]
 	}
-	return rt.lists[flag]
+	panic(throw.IllegalValue())
 }
 
-func (rt *PendingTable) Len() int {
+func (rt PendingTable) Len() int {
 	size := 0
 	for _, list := range rt.lists {
 		size += list.Count()
@@ -50,13 +50,13 @@ type PendingList struct {
 	requests      map[reference.Global]isActive
 }
 
-func NewRequestList() *PendingList {
+func newRequestList() *PendingList {
 	return &PendingList{
 		requests: make(map[reference.Global]isActive),
 	}
 }
 
-func (rl PendingList) Exist(ref reference.Global) bool {
+func (rl *PendingList) Exist(ref reference.Global) bool {
 	_, exist := rl.requests[ref]
 	return exist
 }

--- a/ledger-core/virtual/object/request_table_test.go
+++ b/ledger-core/virtual/object/request_table_test.go
@@ -69,7 +69,7 @@ func TestPendingList(t *testing.T) {
 	RefOne := reference.NewSelf(objectOne)
 	RefTwo := reference.NewSelf(objectTwo)
 
-	rl := NewRequestList()
+	rl := newRequestList()
 	require.Equal(t, 0, rl.Count())
 	require.Equal(t, 0, rl.CountFinish())
 	require.Equal(t, 0, rl.CountActive())
@@ -130,7 +130,7 @@ func TestPendingList_Finish(t *testing.T) {
 	objectTwo := gen.UniqueLocalRefWithPulse(nextPulseNumber)
 	RefTwo := reference.NewSelf(objectTwo)
 
-	rl := NewRequestList()
+	rl := newRequestList()
 
 	require.Equal(t, true, rl.Add(RefOne))
 	require.Equal(t, 1, rl.Count())

--- a/ledger-core/virtual/object/request_table_test.go
+++ b/ledger-core/virtual/object/request_table_test.go
@@ -17,6 +17,22 @@ import (
 	"github.com/insolar/assured-ledger/ledger-core/vanilla/longbits"
 )
 
+func BenchmarkPendingTable(b *testing.B) {
+	var x PendingTable
+	for i := 0; i < b.N; i++ {
+		x = NewRequestTable()
+	}
+	x = x
+}
+
+func BenchmarkWorkingTable(b *testing.B) {
+	var x WorkingTable
+	for i := 0; i < b.N; i++ {
+		x = NewWorkingTable()
+	}
+	x = x
+}
+
 func TestPendingTable(t *testing.T) {
 	rt := NewRequestTable()
 

--- a/ledger-core/virtual/object/working_table.go
+++ b/ledger-core/virtual/object/working_table.go
@@ -14,15 +14,15 @@ import (
 )
 
 type WorkingTable struct {
-	requests [3]*WorkingList
+	requests [contract.InterferenceFlagCount - 1]*WorkingList
 	results  map[reference.Global]Summary
 }
 
 func NewWorkingTable() WorkingTable {
 	var rt WorkingTable
 
-	for i := 1; i < contract.InterferenceFlagCount; i++ {
-		rt.requests[i] = NewWorkingList()
+	for i := len(rt.requests) - 1; i >= 0; i-- {
+		rt.requests[i] = newWorkingList()
 	}
 
 	rt.results = make(map[reference.Global]Summary)
@@ -30,22 +30,22 @@ func NewWorkingTable() WorkingTable {
 	return rt
 }
 
-func (wt *WorkingTable) GetList(flag contract.InterferenceFlag) *WorkingList {
-	if flag.IsZero() || flag >= contract.InterferenceFlagCount {
-		panic(throw.IllegalValue())
+func (wt WorkingTable) GetList(flag contract.InterferenceFlag) *WorkingList {
+	if flag > 0 && int(flag) <= len(wt.requests) {
+		return wt.requests[flag - 1]
 	}
-	return wt.requests[flag]
+	panic(throw.IllegalValue())
 }
 
-func (wt *WorkingTable) GetResults() map[reference.Global]Summary {
+func (wt WorkingTable) GetResults() map[reference.Global]Summary {
 	return wt.results
 }
 
-func (wt *WorkingTable) Add(flag contract.InterferenceFlag, ref reference.Global) bool {
+func (wt WorkingTable) Add(flag contract.InterferenceFlag, ref reference.Global) bool {
 	return wt.GetList(flag).add(ref)
 }
 
-func (wt *WorkingTable) SetActive(flag contract.InterferenceFlag, ref reference.Global) bool {
+func (wt WorkingTable) SetActive(flag contract.InterferenceFlag, ref reference.Global) bool {
 	if ok := wt.GetList(flag).setActive(ref); ok {
 		wt.results[ref] = Summary{}
 
@@ -55,7 +55,7 @@ func (wt *WorkingTable) SetActive(flag contract.InterferenceFlag, ref reference.
 	return false
 }
 
-func (wt *WorkingTable) Finish(
+func (wt WorkingTable) Finish(
 	flag contract.InterferenceFlag,
 	ref reference.Global,
 	result *payload.VCallResult,
@@ -97,7 +97,7 @@ type WorkingList struct {
 	requests            map[reference.Global]WorkingRequestState
 }
 
-func NewWorkingList() *WorkingList {
+func newWorkingList() *WorkingList {
 	return &WorkingList{
 		requests: make(map[reference.Global]WorkingRequestState),
 	}

--- a/ledger-core/virtual/object/working_table.go
+++ b/ledger-core/virtual/object/working_table.go
@@ -14,14 +14,13 @@ import (
 )
 
 type WorkingTable struct {
-	requests []*WorkingList
+	requests [3]*WorkingList
 	results  map[reference.Global]Summary
 }
 
 func NewWorkingTable() WorkingTable {
 	var rt WorkingTable
 
-	rt.requests = make([]*WorkingList, contract.InterferenceFlagCount)
 	for i := 1; i < contract.InterferenceFlagCount; i++ {
 		rt.requests[i] = NewWorkingList()
 	}

--- a/ledger-core/virtual/object/working_table_test.go
+++ b/ledger-core/virtual/object/working_table_test.go
@@ -81,7 +81,7 @@ func TestWorkingList(t *testing.T) {
 	RefOne := reference.NewSelf(objectOne)
 	RefTwo := reference.NewSelf(objectTwo)
 
-	rl := NewWorkingList()
+	rl := newWorkingList()
 	assert.Equal(t, 0, rl.Count())
 	assert.Equal(t, 0, rl.CountFinish())
 	assert.Equal(t, 0, rl.CountActive())
@@ -146,7 +146,7 @@ func TestWorkingList_Finish(t *testing.T) {
 	objectTwo := gen.UniqueLocalRefWithPulse(nextPulseNumber)
 	RefTwo := reference.NewSelf(objectTwo)
 
-	rl := NewWorkingList()
+	rl := newWorkingList()
 
 	assert.Equal(t, true, rl.add(RefOne))
 	assert.Equal(t, 1, rl.Count())

--- a/ledger-core/virtual/object/working_table_test.go
+++ b/ledger-core/virtual/object/working_table_test.go
@@ -34,13 +34,13 @@ func TestWorkingTable(t *testing.T) {
 	ref := reference.NewSelf(object)
 
 	intolerableList := wt.GetList(contract.CallIntolerable)
-	assert.True(t, intolerableList.Add(ref))
+	assert.True(t, intolerableList.add(ref))
 
 	assert.Equal(t, 1, wt.GetList(contract.CallIntolerable).Count())
 	assert.Equal(t, 0, wt.GetList(contract.CallTolerable).Count())
 	assert.Equal(t, pulse.Unknown, wt.GetList(contract.CallIntolerable).EarliestPulse())
 
-	assert.True(t, intolerableList.SetActive(ref))
+	assert.True(t, intolerableList.setActive(ref))
 
 	assert.Equal(t, 1, wt.GetList(contract.CallIntolerable).Count())
 	assert.Equal(t, 0, wt.GetList(contract.CallTolerable).Count())
@@ -87,48 +87,48 @@ func TestWorkingList(t *testing.T) {
 	assert.Equal(t, 0, rl.CountActive())
 	assert.Equal(t, pulse.Number(0), rl.EarliestPulse())
 
-	assert.Equal(t, true, rl.Add(RefOne))
+	assert.Equal(t, true, rl.add(RefOne))
 	assert.Equal(t, RequestStarted, rl.GetState(RefOne))
-	assert.Equal(t, true, rl.SetActive(RefOne))
+	assert.Equal(t, true, rl.setActive(RefOne))
 	assert.Equal(t, 1, rl.Count())
 	assert.Equal(t, 0, rl.CountFinish())
 	assert.Equal(t, 1, rl.CountActive())
 	assert.Equal(t, nextPulseNumber, rl.EarliestPulse())
 
-	assert.Equal(t, false, rl.Add(RefOne))
-	assert.Equal(t, false, rl.SetActive(RefOne))
+	assert.Equal(t, false, rl.add(RefOne))
+	assert.Equal(t, false, rl.setActive(RefOne))
 	assert.Equal(t, RequestProcessing, rl.GetState(RefOne))
 	assert.Equal(t, 1, rl.Count())
 	assert.Equal(t, 0, rl.CountFinish())
 	assert.Equal(t, 1, rl.CountActive())
 	assert.Equal(t, nextPulseNumber, rl.EarliestPulse())
 
-	assert.Equal(t, true, rl.Add(RefOld))
+	assert.Equal(t, true, rl.add(RefOld))
 	assert.Equal(t, RequestProcessing, rl.GetState(RefOne))
 	assert.Equal(t, RequestStarted, rl.GetState(RefOld))
-	assert.Equal(t, true, rl.SetActive(RefOld))
+	assert.Equal(t, true, rl.setActive(RefOld))
 	assert.Equal(t, 2, rl.Count())
 	assert.Equal(t, 0, rl.CountFinish())
 	assert.Equal(t, 2, rl.CountActive())
 	assert.Equal(t, pd.PulseNumber, rl.EarliestPulse())
 
-	assert.Equal(t, true, rl.Add(RefTwo))
+	assert.Equal(t, true, rl.add(RefTwo))
 	assert.Equal(t, RequestProcessing, rl.GetState(RefOne))
 	assert.Equal(t, RequestProcessing, rl.GetState(RefOld))
 	assert.Equal(t, RequestStarted, rl.GetState(RefTwo))
-	assert.Equal(t, true, rl.SetActive(RefTwo))
+	assert.Equal(t, true, rl.setActive(RefTwo))
 	assert.Equal(t, 3, rl.Count())
 	assert.Equal(t, pd.PulseNumber, rl.EarliestPulse())
 	assert.Equal(t, 0, rl.CountFinish())
 	assert.Equal(t, 3, rl.CountActive())
 
-	rl.Finish(RefOne)
+	rl.finish(RefOne)
 	assert.Equal(t, pd.PulseNumber, rl.EarliestPulse()) // doesn't change
 	assert.Equal(t, 1, rl.CountFinish())
 	assert.Equal(t, 2, rl.CountActive())
 
 	// try to finish ref that not in list
-	successFinish := rl.Finish(reference.NewSelf(gen.UniqueLocalRefWithPulse(currentPulse)))
+	successFinish := rl.finish(reference.NewSelf(gen.UniqueLocalRefWithPulse(currentPulse)))
 	assert.Equal(t, false, successFinish)
 	assert.Equal(t, 1, rl.CountFinish())
 	assert.Equal(t, 2, rl.CountActive())
@@ -148,23 +148,23 @@ func TestWorkingList_Finish(t *testing.T) {
 
 	rl := NewWorkingList()
 
-	assert.Equal(t, true, rl.Add(RefOne))
+	assert.Equal(t, true, rl.add(RefOne))
 	assert.Equal(t, 1, rl.Count())
-	assert.Equal(t, true, rl.SetActive(RefOne))
+	assert.Equal(t, true, rl.setActive(RefOne))
 	assert.Equal(t, RequestProcessing, rl.GetState(RefOne))
 	assert.Equal(t, currentPulse, rl.earliestActivePulse)
 	assert.Equal(t, 0, rl.CountFinish())
 	assert.Equal(t, 1, rl.CountActive())
 
-	assert.Equal(t, true, rl.Add(RefTwo))
+	assert.Equal(t, true, rl.add(RefTwo))
 	assert.Equal(t, 2, rl.Count())
-	assert.Equal(t, true, rl.SetActive(RefTwo))
+	assert.Equal(t, true, rl.setActive(RefTwo))
 	assert.Equal(t, RequestProcessing, rl.GetState(RefTwo))
 	assert.Equal(t, currentPulse, rl.earliestActivePulse)
 	assert.Equal(t, 0, rl.CountFinish())
 	assert.Equal(t, 2, rl.CountActive())
 
-	rl.Finish(RefOne)
+	rl.finish(RefOne)
 
 	assert.Equal(t, 1, rl.CountFinish())
 	assert.Equal(t, 1, rl.CountActive())


### PR DESCRIPTION
**- What I did**
- sync tables behaviour
- hide list method that should not be called outside of table
- added bench for memory usage

before
```
pkg: github.com/insolar/assured-ledger/ledger-core/virtual/object
BenchmarkPendingTable-12    	 3951997	       285 ns/op	     304 B/op	       6 allocs/op
BenchmarkWorkingTable-12    	 4537809	       244 ns/op	     240 B/op	       6 allocs/op
```
after
```
goos: darwin
goarch: amd64
pkg: github.com/insolar/assured-ledger/ledger-core/virtual/object
BenchmarkPendingTable-12    	 7344967	       154 ns/op	     160 B/op	       4 allocs/op
BenchmarkWorkingTable-12    	 5528679	       192 ns/op	     208 B/op	       5 allocs/op
```

**- How I did it**

**- How to verify it**

**- Description for the changelog**