### PR TITLE
NOISSUE: Helper for minimock to report full stacktrace

### DIFF
--- a/ledger-core/testutils/mocklog/wrap_t.go
+++ b/ledger-core/testutils/mocklog/wrap_t.go
@@ -1,0 +1,75 @@
+// Copyright 2020 Insolar Network Ltd.
+// All rights reserved.
+// This material is licensed under the Insolar License version 1.0,
+// available at https://github.com/insolar/assured-ledger/blob/master/LICENSE.md.
+
+package mocklog
+
+import (
+	"fmt"
+
+	"github.com/insolar/assured-ledger/ledger-core/vanilla/args"
+	"github.com/insolar/assured-ledger/ledger-core/vanilla/throw"
+)
+
+type Tester interface {
+// 	minimock.Tester
+//	logcommon.TestingLogger
+
+	Fatal(args ...interface{})
+	Fatalf(format string, args ...interface{})
+	Error(...interface{})
+	Errorf(format string, args ...interface{})
+	FailNow()
+
+	Helper()
+	Log(...interface{})
+}
+
+func T(t Tester) Tester {
+	if t == nil {
+		return nil
+	}
+	return stackReport{t}
+}
+
+type stackReport struct {
+	t Tester
+}
+
+func (v stackReport) FailNow() {
+	v.t.FailNow()
+}
+
+func (v stackReport) Helper() {
+	v.t.Helper()
+}
+
+func (v stackReport) Log(args ...interface{}) {
+	v.t.Helper()
+	v.t.Log(args...)
+}
+
+func (v stackReport) Error(a ...interface{}) {
+	v.t.Helper()
+	v.t.Error(args.AppendIntfArgs(a, v.stackText())...)
+}
+
+func (v stackReport) Errorf(format string, args ...interface{}) {
+	v.t.Helper()
+	v.t.Error(fmt.Sprintf(format, args...), v.stackText())
+}
+
+func (v stackReport) Fatal(a ...interface{}) {
+	v.t.Helper()
+	v.t.Fatal(args.AppendIntfArgs(a, v.stackText())...)
+}
+
+func (v stackReport) Fatalf(format string, args ...interface{}) {
+	v.t.Helper()
+	v.t.Fatal(fmt.Sprintf(format, args...), v.stackText())
+}
+
+func (v stackReport) stackText() string {
+	return throw.JoinStackText("", throw.CaptureStack(1))
+}

--- a/ledger-core/testutils/mocklog/wrap_t.go
+++ b/ledger-core/testutils/mocklog/wrap_t.go
@@ -27,8 +27,11 @@ type Tester interface {
 }
 
 func T(t Tester) Tester {
-	if t == nil {
+	switch t.(type) {
+	case nil:
 		return nil
+	case stackReport:
+		return t
 	}
 	return stackReport{t}
 }

--- a/ledger-core/vanilla/args/var_agrs.go
+++ b/ledger-core/vanilla/args/var_agrs.go
@@ -1,0 +1,17 @@
+// Copyright 2020 Insolar Network Ltd.
+// All rights reserved.
+// This material is licensed under the Insolar License version 1.0,
+// available at https://github.com/insolar/assured-ledger/blob/master/LICENSE.md.
+
+package args
+
+func AppendIntfArgs(args []interface{}, moreArgs ...interface{}) []interface{} {
+	switch {
+	case len(moreArgs) == 0:
+		return args
+	case len(args) == 0:
+		return moreArgs
+	default:
+		return append(append(make([]interface{}, 0, len(args) + len(moreArgs)), args...), moreArgs...)
+	}
+}


### PR DESCRIPTION
**- What I did**
* mocklog.T(t) that usable for minimocks to report full stacktrace on errors/fatals