### PR TITLE
PLAT-578: disable graceful stop for network. Will fix it later on

### DIFF
--- a/ledger-core/network/servicenetwork/servicenetwork.go
+++ b/ledger-core/network/servicenetwork/servicenetwork.go
@@ -138,7 +138,9 @@ func (n *ServiceNetwork) GracefulStop(ctx context.Context) error {
 	// all components need to do what they want over net in gracefulStop
 
 	logger.Info("ServiceNetwork.GracefulStop wait for accepting leaving claim")
-	n.TerminationHandler.Leave(ctx, 0)
+	// TODO PLAT-594
+	// For now graceful stop is broken
+	// n.TerminationHandler.Leave(ctx, 0)
 	logger.Info("ServiceNetwork.GracefulStop - leaving claim accepted")
 
 	return nil


### PR DESCRIPTION
**- What I did**
commented graceful stop logic. it is broken and we need to fix it in R1 with new network part

**- How I did it**

**- How to verify it**
Run make test_func, make sure that no insolard nodes left working
