### PR TITLE
PLAT-553: retries limit in SMTestAPICall and fixes

### DIFF
--- a/ledger-core/application/testwalletapi/handlers.go
+++ b/ledger-core/application/testwalletapi/handlers.go
@@ -105,7 +105,7 @@ func (s *TestWalletServer) Create(w http.ResponseWriter, req *http.Request) {
 		ref             reference.Global
 		contractCallErr *foundation.Error
 	)
-	err = foundation.UnmarshalMethodResultSimplified(walletRes.ReturnArguments, &ref, &contractCallErr)
+	err = foundation.UnmarshalMethodResultSimplified(walletRes, &ref, &contractCallErr)
 	switch {
 	case err != nil:
 		result.Error = errors.W(err, "Failed to unmarshal response").Error()
@@ -197,7 +197,7 @@ func (s *TestWalletServer) Transfer(w http.ResponseWriter, req *http.Request) {
 	}
 
 	var contractCallErr *foundation.Error
-	err = foundation.UnmarshalMethodResultSimplified(walletRes.ReturnArguments, &contractCallErr)
+	err = foundation.UnmarshalMethodResultSimplified(walletRes, &contractCallErr)
 	switch {
 	case err != nil:
 		result.Error = throw.W(err, "Failed to unmarshal response", nil).Error()
@@ -279,7 +279,7 @@ func (s *TestWalletServer) GetBalance(w http.ResponseWriter, req *http.Request) 
 		contractCallErr *foundation.Error
 	)
 
-	err = foundation.UnmarshalMethodResultSimplified(walletRes.ReturnArguments, &amount, &contractCallErr)
+	err = foundation.UnmarshalMethodResultSimplified(walletRes, &amount, &contractCallErr)
 	switch {
 	case err != nil:
 		result.Error = throw.W(err, "Failed to unmarshal response", nil).Error()
@@ -361,7 +361,7 @@ func (s *TestWalletServer) AddAmount(w http.ResponseWriter, req *http.Request) {
 	}
 
 	var contractCallErr *foundation.Error
-	err = foundation.UnmarshalMethodResultSimplified(walletRes.ReturnArguments, &contractCallErr)
+	err = foundation.UnmarshalMethodResultSimplified(walletRes, &contractCallErr)
 
 	switch {
 	case err != nil:
@@ -373,7 +373,7 @@ func (s *TestWalletServer) AddAmount(w http.ResponseWriter, req *http.Request) {
 	}
 }
 
-func (s *TestWalletServer) runWalletRequest(ctx context.Context, req payload.VCallRequest) (*payload.VCallResult, error) {
+func (s *TestWalletServer) runWalletRequest(ctx context.Context, req payload.VCallRequest) ([]byte, error) {
 	latestPulse, err := s.accessor.Latest(ctx)
 	if err != nil {
 		return nil, throw.W(err, "Failed to get latest pulse", nil)
@@ -388,7 +388,7 @@ func (s *TestWalletServer) runWalletRequest(ctx context.Context, req payload.VCa
 
 	var (
 		fail error
-		res  payload.VCallResult
+		res  []byte
 	)
 
 	createDefaults := smachine.CreateDefaultValues{
@@ -399,7 +399,7 @@ func (s *TestWalletServer) runWalletRequest(ctx context.Context, req payload.VCa
 
 			fail = data.Error
 
-			resData, ok := data.Result.(payload.VCallResult)
+			resData, ok := data.Result.([]byte)
 			if ok {
 				res = resData
 			}
@@ -425,7 +425,7 @@ func (s *TestWalletServer) runWalletRequest(ctx context.Context, req payload.VCa
 		return nil, throw.W(fail, "Failed to process request", nil)
 	}
 
-	return &res, nil
+	return res, nil
 }
 
 func (s *TestWalletServer) mustWriteResult(w http.ResponseWriter, res interface{}) { // nolint:interfacer

--- a/ledger-core/application/testwalletapi/statemachine/statemachine.go
+++ b/ledger-core/application/testwalletapi/statemachine/statemachine.go
@@ -18,6 +18,7 @@ import (
 	"github.com/insolar/assured-ledger/ledger-core/network/messagesender"
 	messageSenderAdapter "github.com/insolar/assured-ledger/ledger-core/network/messagesender/adapter"
 	"github.com/insolar/assured-ledger/ledger-core/reference"
+	"github.com/insolar/assured-ledger/ledger-core/runner/executor/common/foundation"
 	"github.com/insolar/assured-ledger/ledger-core/testutils/gen"
 	"github.com/insolar/assured-ledger/ledger-core/vanilla/injector"
 	"github.com/insolar/assured-ledger/ledger-core/vanilla/throw"
@@ -25,11 +26,14 @@ import (
 
 var APICaller, _ = reference.GlobalObjectFromString("insolar:0AAABAnRB0CKuqXTeTfQNTolmyixqQGMJz5sVvW81Dng")
 
+const MaxRepeats = 3
+
 type SMTestAPICall struct {
 	requestPayload  payload.VCallRequest
-	responsePayload payload.VCallResult
+	responsePayload []byte
 
-	messageAlreadySent bool
+	object           reference.Global
+	messageSentTimes int
 
 	// injected arguments
 	pulseSlot     *conveyor.PulseSlot
@@ -63,61 +67,88 @@ func (s *SMTestAPICall) GetStateMachineDeclaration() smachine.StateMachineDeclar
 }
 
 func (s *SMTestAPICall) Init(ctx smachine.InitializationContext) smachine.StateUpdate {
-	return ctx.Jump(s.stepRegisterBargeIn)
+	return ctx.Jump(s.stepSend)
 }
 
-func (s *SMTestAPICall) stepRegisterBargeIn(ctx smachine.ExecutionContext) smachine.StateUpdate {
-
+func (s *SMTestAPICall) stepSend(ctx smachine.ExecutionContext) smachine.StateUpdate {
 	s.requestPayload.Caller = APICaller
-	s.requestPayload.CallOutgoing = reference.NewRecordOf(APICaller, gen.UniqueLocalRefWithPulse(s.pulseSlot.PulseData().PulseNumber))
+	outLocal := gen.UniqueLocalRefWithPulse(s.pulseSlot.CurrentPulseNumber())
+	s.requestPayload.CallOutgoing = reference.NewRecordOf(APICaller, outLocal)
 
-	bargeInCallback := ctx.NewBargeInWithParam(func(param interface{}) smachine.BargeInCallbackFunc {
+	switch s.requestPayload.CallType {
+	case payload.CTMethod:
+		s.object = s.requestPayload.Callee
+	case payload.CTConstructor:
+		s.object = reference.NewSelf(outLocal)
+	default:
+		panic(throw.IllegalValue())
+	}
+
+	bargeIn := s.newBargeIn(ctx)
+
+	if !ctx.PublishGlobalAliasAndBargeIn(s.requestPayload.CallOutgoing, bargeIn) {
+		return ctx.Error(errors.New("failed to publish bargeInCallback"))
+	}
+
+	s.sendRequest(ctx)
+
+	ctx.SetDefaultMigration(s.migrateResend)
+
+	return ctx.Jump(s.stepProcessResult)
+}
+
+func (s *SMTestAPICall) stepResend(ctx smachine.ExecutionContext) smachine.StateUpdate {
+	s.sendRequest(ctx)
+	return ctx.Jump(s.stepProcessResult)
+}
+
+func (s *SMTestAPICall) migrateResend(ctx smachine.MigrationContext) smachine.StateUpdate {
+	if s.messageSentTimes >= MaxRepeats {
+		res, err := foundation.MarshalMethodErrorResult(throw.New("timeout: exceeded resend limit"))
+		if err != nil {
+			panic(throw.W(err, "couldn't marshal error"))
+		}
+		s.responsePayload = res
+
+		return ctx.Jump(s.stepProcessResult)
+	}
+	return ctx.Jump(s.stepResend)
+}
+
+func (s *SMTestAPICall) stepProcessResult(ctx smachine.ExecutionContext) smachine.StateUpdate {
+	if s.responsePayload == nil {
+		return ctx.Sleep().ThenRepeat()
+	}
+
+	ctx.SetDefaultTerminationResult(s.responsePayload)
+	return ctx.Stop()
+}
+
+func (s *SMTestAPICall) newBargeIn(ctx smachine.ExecutionContext) smachine.BargeInWithParam {
+	return ctx.NewBargeInWithParam(func(param interface{}) smachine.BargeInCallbackFunc {
 		res, ok := param.(*payload.VCallResult)
 		if !ok || res == nil {
 			panic(throw.IllegalValue())
 		}
 
 		return func(ctx smachine.BargeInContext) smachine.StateUpdate {
-			s.responsePayload = *res
+			s.responsePayload = res.ReturnArguments
 
 			return ctx.WakeUp()
 		}
 	})
-
-	if !ctx.PublishGlobalAliasAndBargeIn(s.requestPayload.CallOutgoing, bargeInCallback) {
-		return ctx.Error(errors.New("failed to publish bargeInCallback"))
-	}
-
-	return ctx.JumpExt(smachine.SlotStep{
-		Transition: s.stepSendRequest,
-		Migration: func(ctx smachine.MigrationContext) smachine.StateUpdate {
-			if !ctx.UnpublishGlobalAlias(s.requestPayload.CallOutgoing) {
-				panic("global alias must exist")
-			}
-			return ctx.Jump(s.stepRegisterBargeIn)
-		},
-	})
 }
 
-func (s *SMTestAPICall) stepSendRequest(ctx smachine.ExecutionContext) smachine.StateUpdate {
-	var obj reference.Global
-	switch s.requestPayload.CallType {
-	case payload.CTMethod:
-		obj = s.requestPayload.Callee
-	case payload.CTConstructor:
-		obj = s.requestPayload.CallOutgoing
-	default:
-		panic(throw.IllegalValue())
-	}
-
+func (s *SMTestAPICall) sendRequest(ctx smachine.ExecutionContext) {
 	payloadData := s.requestPayload
-	if s.messageAlreadySent {
+
+	if s.messageSentTimes > 0 {
 		payloadData.CallRequestFlags.WithRepeatedCall(payload.RepeatedCall)
 	}
 
 	s.messageSender.PrepareAsync(ctx, func(goCtx context.Context, svc messagesender.Service) smachine.AsyncResultFunc {
-		err := svc.SendRole(goCtx, &payloadData, node.DynamicRoleVirtualExecutor, obj, s.pulseSlot.CurrentPulseNumber())
-		s.messageAlreadySent = true
+		err := svc.SendRole(goCtx, &payloadData, node.DynamicRoleVirtualExecutor, s.object, s.pulseSlot.CurrentPulseNumber())
+		s.messageSentTimes++
 		return func(ctx smachine.AsyncResultContext) {
 			if err != nil {
 				ctx.Log().Error("failed to send message", err)
@@ -125,18 +156,4 @@ func (s *SMTestAPICall) stepSendRequest(ctx smachine.ExecutionContext) smachine.
 			}
 		}
 	}).WithoutAutoWakeUp().Start()
-
-	return ctx.Sleep().ThenJumpExt(smachine.SlotStep{
-		Transition: s.stepProcessResult,
-		Migration:  s.migrateBeforeProcessResult,
-	})
-}
-
-func (s *SMTestAPICall) migrateBeforeProcessResult(ctx smachine.MigrationContext) smachine.StateUpdate {
-	return ctx.Jump(s.stepSendRequest)
-}
-
-func (s *SMTestAPICall) stepProcessResult(ctx smachine.ExecutionContext) smachine.StateUpdate {
-	ctx.SetDefaultTerminationResult(s.responsePayload)
-	return ctx.Stop()
 }

--- a/ledger-core/application/testwalletapi/statemachine/statemachine.plantuml
+++ b/ledger-core/application/testwalletapi/statemachine/statemachine.plantuml
@@ -3,26 +3,21 @@ state "Init" as T00_S001
 T00_S001 : SMTestAPICall
 [*] --> T00_S001
 T00_S001 --> T00_S002
-state "migrateBeforeProcessResult" as T00_S006
-T00_S006 : SMTestAPICall
-T00_S006 --> T00_S004
-state "s.messageSender" as T00_S005 <<sdlreceive>>
-state "stepProcessResult" as T00_S007
-T00_S007 : SMTestAPICall
-T00_S007 --[dotted]> T00_S006
-T00_S007 --> [*]
-state "stepRegisterBargeIn" as T00_S002
-T00_S002 : SMTestAPICall
-T00_S002 --[dotted]> T00_S003
-T00_S002 --[dashed]> [*] : [!(...).PublishGlobalAliasAndBargeIn()]\nError
-T00_S002 --> T00_S004 : Migrate: stepRegisterBargeIn.1
-state "stepRegisterBargeIn.1" as T00_S003
-T00_S003 : SMTestAPICall
-T00_S003 --> T00_S002
-state "stepSendRequest" as T00_S004
+state "migrateResend" as T00_S004
 T00_S004 : SMTestAPICall
-T00_S004 --[dotted]> T00_S006
-T00_S004 --[dotted]> T00_S003
-T00_S004 --> T00_S005 : PrepareAsync(ctx).WithoutAutoWakeUp()
-T00_S004 --[dashed]> T00_S007 : Migrate: s.migrateBeforeProcessResult\nSleep
+T00_S004 --> T00_S005 : [s.messageSentTimes>=MaxRepeats]
+T00_S004 --> T00_S003
+state "stepProcessResult" as T00_S005
+T00_S005 : SMTestAPICall
+T00_S005 --[dotted]> T00_S004
+T00_S005 --[dashed]> T00_S005 : [s.responsePayload==nil]\nSleep
+T00_S005 --> [*]
+state "stepResend" as T00_S003
+T00_S003 : SMTestAPICall
+T00_S003 --[dotted]> T00_S004
+T00_S003 --> T00_S005
+state "stepSend" as T00_S002
+T00_S002 : SMTestAPICall
+T00_S002 --[dashed]> [*] : [!(...).PublishGlobalAliasAndBargeIn()]\nError
+T00_S002 --> T00_S005 : Migrate: s.migrateResend
 @enduml

--- a/ledger-core/application/testwalletapi/statemachine/statemachine_test.go
+++ b/ledger-core/application/testwalletapi/statemachine/statemachine_test.go
@@ -14,9 +14,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"gotest.tools/assert"
 
-	"github.com/insolar/assured-ledger/ledger-core/application/builtin/proxy/testwallet"
-	"github.com/insolar/assured-ledger/ledger-core/conveyor/smachine"
-	"github.com/insolar/assured-ledger/ledger-core/insolar"
 	"github.com/insolar/assured-ledger/ledger-core/insolar/contract"
 	"github.com/insolar/assured-ledger/ledger-core/insolar/node"
 	"github.com/insolar/assured-ledger/ledger-core/insolar/payload"
@@ -24,28 +21,27 @@ import (
 	"github.com/insolar/assured-ledger/ledger-core/network/messagesender"
 	"github.com/insolar/assured-ledger/ledger-core/pulse"
 	"github.com/insolar/assured-ledger/ledger-core/reference"
+	"github.com/insolar/assured-ledger/ledger-core/runner/executor/common/foundation"
 	"github.com/insolar/assured-ledger/ledger-core/testutils/gen"
 	"github.com/insolar/assured-ledger/ledger-core/testutils/slotdebugger"
+	"github.com/insolar/assured-ledger/ledger-core/vanilla/throw"
 	"github.com/insolar/assured-ledger/ledger-core/virtual/testutils"
 )
 
-func TestSMTestAPICall_Migrate_After_RegisterBargeIn(t *testing.T) {
+func TestSMTestAPICall_MethodResends(t *testing.T) {
 	var (
 		mc  = minimock.NewController(t)
 		ctx = instestlogger.TestContext(t)
 	)
 
-	slotMachine := slotdebugger.NewWithIgnoreAllErrors(ctx, t)
+	slotMachine := slotdebugger.New(ctx, t)
 
 	request := payload.VCallRequest{
-		CallType:            payload.CTMethod,
-		Callee:              gen.UniqueGlobalRef(),
-		Caller:              gen.UniqueGlobalRef(),
-		CallFlags:           payload.BuildCallFlags(contract.CallTolerable, contract.CallDirty),
-		CallSiteDeclaration: testwallet.GetClass(),
-		CallSiteMethod:      "New",
-		CallOutgoing:        gen.UniqueGlobalRef(),
-		Arguments:           insolar.MustSerialize([]interface{}{}),
+		CallType:       payload.CTMethod,
+		Callee:         gen.UniqueGlobalRef(),
+		CallFlags:      payload.BuildCallFlags(contract.CallTolerable, contract.CallDirty),
+		CallSiteMethod: "New",
+		Arguments:      []byte("some args"),
 	}
 
 	slotMachine.PrepareMockedMessageSender(mc)
@@ -57,80 +53,17 @@ func TestSMTestAPICall_Migrate_After_RegisterBargeIn(t *testing.T) {
 		requestPayload: request,
 	}
 
-	smWrapper := slotMachine.AddStateMachine(ctx, &smRequest)
-
-	slotMachine.RunTil(smWrapper.BeforeStep(smRequest.stepRegisterBargeIn))
-
-	require.NotEqual(t, APICaller, smRequest.requestPayload.Caller)
-	slotMachine.RunTil(smWrapper.AfterStep(smRequest.stepRegisterBargeIn))
-
-	outgoingRef := smRequest.requestPayload.CallOutgoing
-	_, bargeIn := slotMachine.SlotMachine.GetPublishedGlobalAliasAndBargeIn(outgoingRef)
-	require.NotNil(t, bargeIn)
-
-	require.Equal(t, APICaller, smRequest.requestPayload.Caller)
-	require.NotEmpty(t, smRequest.requestPayload.CallOutgoing)
-
-	{
-		slotMachine.Migrate()
-		slotMachine.RunTil(smWrapper.AfterAnyMigrate())
-		// check that we remove bargein after migrate
-		_, bargeIn = slotMachine.SlotMachine.GetPublishedGlobalAliasAndBargeIn(outgoingRef)
-		require.Nil(t, bargeIn)
-	}
-
-	slotMachine.RunTil(smWrapper.AfterStep(smRequest.stepRegisterBargeIn))
-	newOutgoingRef := smRequest.requestPayload.CallOutgoing
-	var newBargeIn smachine.BargeInHolder
-	{
-		require.NotEqual(t, newOutgoingRef, outgoingRef)
-		// check that we create new bargein
-		_, newBargeIn = slotMachine.SlotMachine.GetPublishedGlobalAliasAndBargeIn(newOutgoingRef)
-		require.NotNil(t, newBargeIn)
-	}
-}
-
-func TestSMTestAPICall_Migrate_After_SendRequest(t *testing.T) {
-	var (
-		mc  = minimock.NewController(t)
-		ctx = instestlogger.TestContext(t)
-	)
-
-	slotMachine := slotdebugger.NewWithIgnoreAllErrors(ctx, t)
-
-	request := payload.VCallRequest{
-		CallType:            payload.CTMethod,
-		Callee:              gen.UniqueGlobalRef(),
-		Caller:              gen.UniqueGlobalRef(),
-		CallFlags:           payload.BuildCallFlags(contract.CallTolerable, contract.CallDirty),
-		CallSiteDeclaration: testwallet.GetClass(),
-		CallSiteMethod:      "New",
-		CallOutgoing:        gen.UniqueGlobalRef(),
-		Arguments:           insolar.MustSerialize([]interface{}{}),
-	}
-
-	slotMachine.PrepareMockedMessageSender(mc)
-
-	slotMachine.Start()
-	defer slotMachine.Stop()
-
-	smRequest := SMTestAPICall{
-		requestPayload: request,
-	}
+	p1 := slotMachine.PulseSlot.CurrentPulseNumber()
 
 	smWrapper := slotMachine.AddStateMachine(ctx, &smRequest)
-
-	slotMachine.RunTil(smWrapper.AfterStep(smRequest.stepRegisterBargeIn))
-
-	outgoingRef := smRequest.requestPayload.CallOutgoing
-	_, bargeIn := slotMachine.SlotMachine.GetPublishedGlobalAliasAndBargeIn(outgoingRef)
-	require.NotNil(t, bargeIn)
 
 	messageSent := make(chan struct{}, 1)
 	slotMachine.MessageSender.SendRole.Set(func(_ context.Context, msg payload.Marshaler, role node.DynamicRole, object reference.Global, pn pulse.Number, _ ...messagesender.SendOption) error {
 		res := msg.(*payload.VCallRequest)
 		// ensure that both times request is the same
-		assert.Equal(t, outgoingRef, res.CallOutgoing)
+		assert.Equal(t, APICaller, res.Caller)
+		assert.Equal(t, APICaller.GetBase(), res.CallOutgoing.GetBase())
+		assert.Equal(t, p1, res.CallOutgoing.GetLocal().GetPulseNumber())
 		assert.Equal(t, node.DynamicRoleVirtualExecutor, role)
 		assert.Equal(t, request.Callee, object)
 
@@ -138,23 +71,127 @@ func TestSMTestAPICall_Migrate_After_SendRequest(t *testing.T) {
 		return nil
 	})
 
-	slotMachine.RunTil(smWrapper.AfterStep(smRequest.stepSendRequest))
+	slotMachine.RunTil(smWrapper.BeforeStep(smRequest.stepProcessResult))
 	testutils.WaitSignalsTimed(t, 10*time.Second, messageSent)
-	slotMachine.Migrate()
 
-	slotMachine.RunTil(smWrapper.AfterStep(smRequest.stepSendRequest))
+	slotMachine.Migrate()
+	slotMachine.RunTil(smWrapper.AfterAnyMigrate())
+
+	slotMachine.RunTil(smWrapper.BeforeStep(smRequest.stepProcessResult))
 	testutils.WaitSignalsTimed(t, 10*time.Second, messageSent)
 
 	response := &payload.VCallResult{
 		Caller:   gen.UniqueGlobalRef(),
 		Callee:   gen.UniqueGlobalRef(),
 		CallAsOf: gen.PulseNumber(),
+		ReturnArguments: []byte("some results"),
 	}
+
+	outgoingRef := smRequest.requestPayload.CallOutgoing
+	_, bargeIn := slotMachine.SlotMachine.GetPublishedGlobalAliasAndBargeIn(outgoingRef)
+	require.NotNil(t, bargeIn)
 
 	// simulate received VCallResult
 	require.True(t, bargeIn.CallWithParam(response))
 
 	slotMachine.RunTil(smWrapper.BeforeStep(smRequest.stepProcessResult))
-	require.Equal(t, *response, smRequest.responsePayload)
+	require.Equal(t, []byte("some results"), smRequest.responsePayload)
+	slotMachine.RunTil(smWrapper.AfterStop())
+}
+
+func TestSMTestAPICall_Constructor(t *testing.T) {
+	var (
+		mc  = minimock.NewController(t)
+		ctx = instestlogger.TestContext(t)
+	)
+
+	slotMachine := slotdebugger.New(ctx, t)
+
+	request := payload.VCallRequest{
+		CallType:       payload.CTConstructor,
+		Callee:         gen.UniqueGlobalRef(),
+		CallFlags:      payload.BuildCallFlags(contract.CallTolerable, contract.CallDirty),
+		CallSiteMethod: "New",
+		Arguments:      []byte("some args"),
+	}
+
+	slotMachine.PrepareMockedMessageSender(mc)
+
+	slotMachine.Start()
+	defer slotMachine.Stop()
+
+	smRequest := SMTestAPICall{
+		requestPayload: request,
+	}
+
+	p1 := slotMachine.PulseSlot.CurrentPulseNumber()
+
+	smWrapper := slotMachine.AddStateMachine(ctx, &smRequest)
+
+	messageSent := make(chan struct{}, 1)
+	slotMachine.MessageSender.SendRole.Set(func(_ context.Context, msg payload.Marshaler, role node.DynamicRole, object reference.Global, pn pulse.Number, _ ...messagesender.SendOption) error {
+		res := msg.(*payload.VCallRequest)
+
+		// ensure that both times request is the same
+		assert.Equal(t, APICaller, res.Caller)
+		assert.Equal(t, APICaller.GetBase(), res.CallOutgoing.GetBase())
+		assert.Equal(t, p1, res.CallOutgoing.GetLocal().GetPulseNumber())
+		assert.Equal(t, node.DynamicRoleVirtualExecutor, role)
+		assert.Equal(t, reference.NewSelf(res.CallOutgoing.GetLocal()), object)
+
+		messageSent <- struct{}{}
+		return nil
+	})
+
+	slotMachine.RunTil(smWrapper.BeforeStep(smRequest.stepProcessResult))
+	testutils.WaitSignalsTimed(t, 10*time.Second, messageSent)
+}
+
+const expectedMaxRetries = 3
+
+func TestSMTestAPICall_RetriesExceeded(t *testing.T) {
+	var (
+		mc  = minimock.NewController(t)
+		ctx = instestlogger.TestContext(t)
+	)
+
+	slotMachine := slotdebugger.New(ctx, t)
+
+	request := payload.VCallRequest{
+		CallType:       payload.CTMethod,
+		Callee:         gen.UniqueGlobalRef(),
+		CallFlags:      payload.BuildCallFlags(contract.CallTolerable, contract.CallDirty),
+		CallSiteMethod: "New",
+		Arguments:      []byte("some args"),
+	}
+
+	slotMachine.PrepareMockedMessageSender(mc)
+
+	slotMachine.Start()
+	defer slotMachine.Stop()
+
+	smRequest := SMTestAPICall{
+		requestPayload: request,
+	}
+
+	smWrapper := slotMachine.AddStateMachine(ctx, &smRequest)
+
+	messageSent := make(chan struct{}, 1)
+	slotMachine.MessageSender.SendRole.Set(func(_ context.Context, msg payload.Marshaler, role node.DynamicRole, object reference.Global, pn pulse.Number, _ ...messagesender.SendOption) error {
+		messageSent <- struct{}{}
+		return nil
+	})
+
+	for i := 0; i < expectedMaxRetries; i++ {
+		slotMachine.RunTil(smWrapper.BeforeStep(smRequest.stepProcessResult))
+		testutils.WaitSignalsTimed(t, 10*time.Second, messageSent)
+		slotMachine.Migrate()
+		slotMachine.RunTil(smWrapper.AfterAnyMigrate())
+	}
+
+	slotMachine.RunTil(smWrapper.BeforeStep(smRequest.stepProcessResult))
+	res, err := foundation.MarshalMethodErrorResult(throw.New("timeout: exceeded resend limit"))
+	require.NoError(t, err)
+	require.Equal(t, res, smRequest.responsePayload)
 	slotMachine.RunTil(smWrapper.AfterStop())
 }


### PR DESCRIPTION
* limit number of retries
* object was not calculated correctly constructors
* idea of unpublishing bargein was not working, pulse was the same all
  the time, just placed first send into one step and resend into
  another
* set migration after first send
* write tests
