### PR TITLE
[Merged by Bors] - PLAT-616: fix test TestVirtual_Constructor_PulseChangedWhileOutgoing

### DIFF
--- a/ledger-core/virtual/integration/constructor_test.go
+++ b/ledger-core/virtual/integration/constructor_test.go
@@ -762,7 +762,7 @@ func TestVirtual_Constructor_PulseChangedWhileOutgoing(t *testing.T) {
 	server.SendPayload(ctx, &msgVStateRequest)
 	server.WaitActiveThenIdleConveyor()
 
-	testutils.WaitSignalsTimed(t, 10*time.Second, typedChecker.VStateReport.Wait(2))
+	testutils.WaitSignalsTimed(t, 10*time.Second, typedChecker.VStateReport.Wait(ctx, 2))
 
 	{
 		assert.Equal(t, 1, typedChecker.VCallResult.Count())

--- a/ledger-core/virtual/integration/constructor_test.go
+++ b/ledger-core/virtual/integration/constructor_test.go
@@ -750,6 +750,10 @@ func TestVirtual_Constructor_PulseChangedWhileOutgoing(t *testing.T) {
 
 	synchronizeExecution.WakeUp()
 
+	synchronizeExecution.Done()
+	testutils.WaitSignalsTimed(t, 10*time.Second, executeDone)
+	testutils.WaitSignalsTimed(t, 10*time.Second, server.Journal.WaitAllAsyncCallsDone())
+
 	msgVStateRequest := payload.VStateRequest{
 		AsOf:   constructorPulse,
 		Object: outgoing,
@@ -758,9 +762,7 @@ func TestVirtual_Constructor_PulseChangedWhileOutgoing(t *testing.T) {
 	server.SendPayload(ctx, &msgVStateRequest)
 	server.WaitActiveThenIdleConveyor()
 
-	synchronizeExecution.Done()
-	testutils.WaitSignalsTimed(t, 10*time.Second, executeDone)
-	testutils.WaitSignalsTimed(t, 10*time.Second, server.Journal.WaitAllAsyncCallsDone())
+	testutils.WaitSignalsTimed(t, 10*time.Second, typedChecker.VStateReport.Wait(2))
 
 	{
 		assert.Equal(t, 1, typedChecker.VCallResult.Count())

--- a/ledger-core/virtual/integration/mock/typepublishchecker.go
+++ b/ledger-core/virtual/integration/mock/typepublishchecker.go
@@ -7,7 +7,7 @@ package mock
 
 import (
 	"context"
-	mm_time "time"
+	"time"
 
 	"github.com/ThreeDotsLabs/watermill/message"
 	"github.com/gojuno/minimock/v3"
@@ -44,8 +44,8 @@ func (p PubVCallRequestMock) Count() int {
 	return p.parent.Handlers.VCallRequest.count.Load()
 }
 
-func (p PubVCallRequestMock) Wait(count int) synckit.SignalChannel {
-	return waitCounterIndefinitely(&p.parent.Handlers.VCallRequest.count, count)
+func (p PubVCallRequestMock) Wait(ctx context.Context, count int) synckit.SignalChannel {
+	return waitCounterIndefinitely(ctx, &p.parent.Handlers.VCallRequest.count, count)
 }
 
 // ============================================================================
@@ -75,8 +75,8 @@ func (p PubVCallResultMock) Count() int {
 	return p.parent.Handlers.VCallResult.count.Load()
 }
 
-func (p PubVCallResultMock) Wait(count int) synckit.SignalChannel {
-	return waitCounterIndefinitely(&p.parent.Handlers.VCallResult.count, count)
+func (p PubVCallResultMock) Wait(ctx context.Context, count int) synckit.SignalChannel {
+	return waitCounterIndefinitely(ctx, &p.parent.Handlers.VCallResult.count, count)
 }
 
 // ============================================================================
@@ -106,8 +106,8 @@ func (p PubVDelegatedCallRequestMock) Count() int {
 	return p.parent.Handlers.VDelegatedCallRequest.count.Load()
 }
 
-func (p PubVDelegatedCallRequestMock) Wait(count int) synckit.SignalChannel {
-	return waitCounterIndefinitely(&p.parent.Handlers.VDelegatedCallRequest.count, count)
+func (p PubVDelegatedCallRequestMock) Wait(ctx context.Context, count int) synckit.SignalChannel {
+	return waitCounterIndefinitely(ctx, &p.parent.Handlers.VDelegatedCallRequest.count, count)
 }
 
 // ============================================================================
@@ -137,8 +137,8 @@ func (p PubVDelegatedCallResponseMock) Count() int {
 	return p.parent.Handlers.VDelegatedCallResponse.count.Load()
 }
 
-func (p PubVDelegatedCallResponseMock) Wait(count int) synckit.SignalChannel {
-	return waitCounterIndefinitely(&p.parent.Handlers.VDelegatedCallResponse.count, count)
+func (p PubVDelegatedCallResponseMock) Wait(ctx context.Context, count int) synckit.SignalChannel {
+	return waitCounterIndefinitely(ctx, &p.parent.Handlers.VDelegatedCallResponse.count, count)
 }
 
 // ============================================================================
@@ -168,8 +168,8 @@ func (p PubVDelegatedRequestFinishedMock) Count() int {
 	return p.parent.Handlers.VDelegatedRequestFinished.count.Load()
 }
 
-func (p PubVDelegatedRequestFinishedMock) Wait(count int) synckit.SignalChannel {
-	return waitCounterIndefinitely(&p.parent.Handlers.VDelegatedRequestFinished.count, count)
+func (p PubVDelegatedRequestFinishedMock) Wait(ctx context.Context, count int) synckit.SignalChannel {
+	return waitCounterIndefinitely(ctx, &p.parent.Handlers.VDelegatedRequestFinished.count, count)
 }
 
 // ============================================================================
@@ -199,8 +199,8 @@ func (p PubVStateRequestMock) Count() int {
 	return p.parent.Handlers.VStateRequest.count.Load()
 }
 
-func (p PubVStateRequestMock) Wait(count int) synckit.SignalChannel {
-	return waitCounterIndefinitely(&p.parent.Handlers.VStateRequest.count, count)
+func (p PubVStateRequestMock) Wait(ctx context.Context, count int) synckit.SignalChannel {
+	return waitCounterIndefinitely(ctx, &p.parent.Handlers.VStateRequest.count, count)
 }
 
 // ============================================================================
@@ -230,8 +230,8 @@ func (p PubVStateReportMock) Count() int {
 	return p.parent.Handlers.VStateReport.count.Load()
 }
 
-func (p PubVStateReportMock) Wait(count int) synckit.SignalChannel {
-	return waitCounterIndefinitely(&p.parent.Handlers.VStateReport.count, count)
+func (p PubVStateReportMock) Wait(ctx context.Context, count int) synckit.SignalChannel {
+	return waitCounterIndefinitely(ctx, &p.parent.Handlers.VStateReport.count, count)
 }
 
 // ============================================================================
@@ -261,8 +261,8 @@ func (p PubVFindCallRequestMock) Count() int {
 	return p.parent.Handlers.VFindCallRequest.count.Load()
 }
 
-func (p PubVFindCallRequestMock) Wait(count int) synckit.SignalChannel {
-	return waitCounterIndefinitely(&p.parent.Handlers.VFindCallRequest.count, count)
+func (p PubVFindCallRequestMock) Wait(ctx context.Context, count int) synckit.SignalChannel {
+	return waitCounterIndefinitely(ctx, &p.parent.Handlers.VFindCallRequest.count, count)
 }
 
 // ============================================================================
@@ -292,8 +292,8 @@ func (p PubVFindCallResponseMock) Count() int {
 	return p.parent.Handlers.VFindCallResponse.count.Load()
 }
 
-func (p PubVFindCallResponseMock) Wait(count int) synckit.SignalChannel {
-	return waitCounterIndefinitely(&p.parent.Handlers.VFindCallResponse.count, count)
+func (p PubVFindCallResponseMock) Wait(ctx context.Context, count int) synckit.SignalChannel {
+	return waitCounterIndefinitely(ctx, &p.parent.Handlers.VFindCallResponse.count, count)
 }
 
 // ============================================================================
@@ -657,8 +657,8 @@ func (p *TypePublishChecker) MinimockFinish() {
 }
 
 // MinimockWait waits for all mocked methods to be called the expected number of times
-func (p *TypePublishChecker) MinimockWait(timeout mm_time.Duration) {
-	timeoutCh := mm_time.After(timeout)
+func (p *TypePublishChecker) MinimockWait(timeout time.Duration) {
+	timeoutCh := time.After(timeout)
 	for {
 		if p.minimockDone() {
 			return
@@ -667,12 +667,12 @@ func (p *TypePublishChecker) MinimockWait(timeout mm_time.Duration) {
 		case <-timeoutCh:
 			p.MinimockFinish()
 			return
-		case <-mm_time.After(10 * mm_time.Millisecond):
+		case <-time.After(10 * time.Millisecond):
 		}
 	}
 }
 
-func waitCounterIndefinitely(counter *atomickit.Int, count int) synckit.SignalChannel {
+func waitCounterIndefinitely(ctx context.Context, counter *atomickit.Int, count int) synckit.SignalChannel {
 	ch := make(synckit.ClosableSignalChannel)
 	go func() {
 		defer close(ch)
@@ -682,7 +682,11 @@ func waitCounterIndefinitely(counter *atomickit.Int, count int) synckit.SignalCh
 			if c >= count {
 				return
 			}
-			mm_time.Sleep(1*mm_time.Millisecond)
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(1 * time.Millisecond):
+			}
 		}
 	}()
 	return ch

--- a/ledger-core/virtual/integration/mock/typepublishchecker.go
+++ b/ledger-core/virtual/integration/mock/typepublishchecker.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/insolar/assured-ledger/ledger-core/insolar/payload"
 	"github.com/insolar/assured-ledger/ledger-core/vanilla/atomickit"
+	"github.com/insolar/assured-ledger/ledger-core/vanilla/synckit"
 )
 
 // ============================================================================
@@ -43,6 +44,10 @@ func (p PubVCallRequestMock) Count() int {
 	return p.parent.Handlers.VCallRequest.count.Load()
 }
 
+func (p PubVCallRequestMock) Wait(count int) synckit.SignalChannel {
+	return waitCounterIndefinitely(&p.parent.Handlers.VCallRequest.count, count)
+}
+
 // ============================================================================
 
 type VCallResultHandler func(*payload.VCallResult) bool
@@ -68,6 +73,10 @@ func (p PubVCallResultMock) SetResend(resend bool) PubVCallResultMock {
 
 func (p PubVCallResultMock) Count() int {
 	return p.parent.Handlers.VCallResult.count.Load()
+}
+
+func (p PubVCallResultMock) Wait(count int) synckit.SignalChannel {
+	return waitCounterIndefinitely(&p.parent.Handlers.VCallResult.count, count)
 }
 
 // ============================================================================
@@ -97,6 +106,10 @@ func (p PubVDelegatedCallRequestMock) Count() int {
 	return p.parent.Handlers.VDelegatedCallRequest.count.Load()
 }
 
+func (p PubVDelegatedCallRequestMock) Wait(count int) synckit.SignalChannel {
+	return waitCounterIndefinitely(&p.parent.Handlers.VDelegatedCallRequest.count, count)
+}
+
 // ============================================================================
 
 type VDelegatedCallResponseHandler func(*payload.VDelegatedCallResponse) bool
@@ -122,6 +135,10 @@ func (p PubVDelegatedCallResponseMock) SetResend(resend bool) PubVDelegatedCallR
 
 func (p PubVDelegatedCallResponseMock) Count() int {
 	return p.parent.Handlers.VDelegatedCallResponse.count.Load()
+}
+
+func (p PubVDelegatedCallResponseMock) Wait(count int) synckit.SignalChannel {
+	return waitCounterIndefinitely(&p.parent.Handlers.VDelegatedCallResponse.count, count)
 }
 
 // ============================================================================
@@ -151,6 +168,10 @@ func (p PubVDelegatedRequestFinishedMock) Count() int {
 	return p.parent.Handlers.VDelegatedRequestFinished.count.Load()
 }
 
+func (p PubVDelegatedRequestFinishedMock) Wait(count int) synckit.SignalChannel {
+	return waitCounterIndefinitely(&p.parent.Handlers.VDelegatedRequestFinished.count, count)
+}
+
 // ============================================================================
 
 type VStateRequestHandler func(*payload.VStateRequest) bool
@@ -176,6 +197,10 @@ func (p PubVStateRequestMock) SetResend(resend bool) PubVStateRequestMock {
 
 func (p PubVStateRequestMock) Count() int {
 	return p.parent.Handlers.VStateRequest.count.Load()
+}
+
+func (p PubVStateRequestMock) Wait(count int) synckit.SignalChannel {
+	return waitCounterIndefinitely(&p.parent.Handlers.VStateRequest.count, count)
 }
 
 // ============================================================================
@@ -205,6 +230,10 @@ func (p PubVStateReportMock) Count() int {
 	return p.parent.Handlers.VStateReport.count.Load()
 }
 
+func (p PubVStateReportMock) Wait(count int) synckit.SignalChannel {
+	return waitCounterIndefinitely(&p.parent.Handlers.VStateReport.count, count)
+}
+
 // ============================================================================
 
 type VFindCallRequestHandler func(*payload.VFindCallRequest) bool
@@ -232,6 +261,10 @@ func (p PubVFindCallRequestMock) Count() int {
 	return p.parent.Handlers.VFindCallRequest.count.Load()
 }
 
+func (p PubVFindCallRequestMock) Wait(count int) synckit.SignalChannel {
+	return waitCounterIndefinitely(&p.parent.Handlers.VFindCallRequest.count, count)
+}
+
 // ============================================================================
 
 type VFindCallResponseHandler func(*payload.VFindCallResponse) bool
@@ -257,6 +290,10 @@ func (p PubVFindCallResponseMock) SetResend(resend bool) PubVFindCallResponseMoc
 
 func (p PubVFindCallResponseMock) Count() int {
 	return p.parent.Handlers.VFindCallResponse.count.Load()
+}
+
+func (p PubVFindCallResponseMock) Wait(count int) synckit.SignalChannel {
+	return waitCounterIndefinitely(&p.parent.Handlers.VFindCallResponse.count, count)
 }
 
 // ============================================================================
@@ -633,4 +670,20 @@ func (p *TypePublishChecker) MinimockWait(timeout mm_time.Duration) {
 		case <-mm_time.After(10 * mm_time.Millisecond):
 		}
 	}
+}
+
+func waitCounterIndefinitely(counter *atomickit.Int, count int) synckit.SignalChannel {
+	ch := make(synckit.ClosableSignalChannel)
+	go func() {
+		defer close(ch)
+
+		for {
+			c := counter.Load()
+			if c >= count {
+				return
+			}
+			mm_time.Sleep(1*mm_time.Millisecond)
+		}
+	}()
+	return ch
 }


### PR DESCRIPTION
* wait for message to be send before asserting counter
* test case expected execution to be finished and only after that
  VStateRequest should be send into the system