### PR TITLE
[Merged by Bors] - Plat-570: test dt check fail if no dt and source != expectedVE

### DIFF
--- a/ledger-core/virtual/integration/delegationtoken_test.go
+++ b/ledger-core/virtual/integration/delegationtoken_test.go
@@ -299,3 +299,82 @@ func TestDelegationToken_CheckFailIfSenderEqApprover(t *testing.T) {
 	}
 	mc.Finish()
 }
+
+func TestDelegationToken_CheckFailIfZeroDTAndSenderNEqExpectedVE(t *testing.T) {
+	t.Log("C5196")
+	cases := []struct {
+		name string
+		msg  interface{}
+	}{
+		{
+			name: "VCallRequest",
+			msg:  &payload.VCallRequest{},
+		},
+		{
+			name: "VCallResult",
+			msg:  &payload.VCallResult{},
+		},
+		{
+			name: "VStateReport",
+			msg:  &payload.VStateReport{},
+		},
+		{
+			name: "VStateRequest",
+			msg:  &payload.VStateRequest{},
+		},
+		{
+			name: "VDelegatedCallRequest",
+			msg:  &payload.VDelegatedCallRequest{},
+		},
+		{
+			name: "VDelegatedRequestFinished",
+			msg:  &payload.VDelegatedRequestFinished{},
+		},
+	}
+
+	mc := minimock.NewController(t)
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			server, ctx := utils.NewUninitializedServer(nil, t)
+
+			jetCoordinatorMock := jet.NewAffinityHelperMock(t)
+			auth := authentication.NewService(ctx, jetCoordinatorMock)
+			server.ReplaceAuthenticationService(auth)
+
+			var errorFound bool
+			logHandler := func(arg interface{}) {
+				if err, ok := arg.(error); ok {
+					errMsg := err.Error()
+					if strings.Contains(errMsg, "unexpected sender") &&
+						strings.Contains(errMsg, "illegitimate msg") {
+						errorFound = true
+					}
+				}
+			}
+			logger := utils.InterceptLog(inslogger.FromContext(ctx), logHandler)
+			server.OverrideConveyorFactoryLogContext(inslogger.SetLogger(ctx, logger))
+
+			server.Init(ctx)
+			// increment pulse for VStateReport and VDelegatedCallRequest
+			server.IncrementPulse(ctx)
+
+			approver := server.RandomGlobalWithPulse()
+			jetCoordinatorMock.
+				QueryRoleMock.Return([]reference.Global{approver}, nil)
+
+			delegationToken := payload.CallDelegationToken{
+				TokenTypeAndFlags: payload.DelegationTokenTypeUninitialized,
+			}
+			reflect.ValueOf(testCase.msg).MethodByName("Reset").Call([]reflect.Value{})
+			insertToken(delegationToken, testCase.msg)
+
+			server.SendPayload(ctx, testCase.msg.(payload.Marshaler))
+			server.WaitIdleConveyor()
+
+			assert.True(t, errorFound)
+			server.Stop()
+		})
+	}
+	mc.Finish()
+}

--- a/ledger-core/virtual/integration/delegationtoken_test.go
+++ b/ledger-core/virtual/integration/delegationtoken_test.go
@@ -148,7 +148,7 @@ type testCase struct {
 	approverVE    veSetMode
 	currentVE     veSetMode
 	errorMessages []string
-	errorSeverity []throw.Severity
+	errorSeverity throw.Severity
 }
 
 func TestDelegationToken_IsMessageFromVirtualLegitimate(t *testing.T) {
@@ -163,7 +163,7 @@ func TestDelegationToken_IsMessageFromVirtualLegitimate(t *testing.T) {
 				"unexpected sender",
 				"illegitimate msg",
 			},
-			errorSeverity: []throw.Severity{},
+			errorSeverity: 0,
 		},
 		{
 			name:       "Fail if sender eq approver",
@@ -175,9 +175,7 @@ func TestDelegationToken_IsMessageFromVirtualLegitimate(t *testing.T) {
 				"sender cannot be approver of the token",
 				"illegitimate msg",
 			},
-			errorSeverity: []throw.Severity{
-				throw.FraudSeverity,
-			},
+			errorSeverity: throw.FraudSeverity,
 		},
 		{
 			name:       "Fail if wrong approver",
@@ -189,7 +187,7 @@ func TestDelegationToken_IsMessageFromVirtualLegitimate(t *testing.T) {
 				"token Approver and expectedVE are different",
 				"illegitimate msg",
 			},
-			errorSeverity: []throw.Severity{},
+			errorSeverity: 0,
 		},
 	}
 	messages := []struct {
@@ -240,8 +238,8 @@ func TestDelegationToken_IsMessageFromVirtualLegitimate(t *testing.T) {
 					if !ok {
 						return
 					}
-					for _, severity := range testCase.errorSeverity {
-						if s, sok := throw.GetSeverity(err); sok && s != severity {
+					if testCase.errorSeverity > 0 {
+						if s, sok := throw.GetSeverity(err); (sok && s != testCase.errorSeverity) || !sok {
 							return
 						}
 					}


### PR DESCRIPTION
Test that execution will stopped if message have zero DT and source not equal expected VE

Combine test for PLAT-570, PLAT-565 and PLAT-564 into one tabular test

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
