### PR TITLE
PLAT-367: get rid of IgnoreAllErrors from most of the tests

### DIFF
--- a/ledger-core/application/api/availability_test.go
+++ b/ledger-core/application/api/availability_test.go
@@ -43,7 +43,8 @@ func TestAvailabilityChecker_UpdateStatus(t *testing.T) {
 	instestlogger.SetTestOutputWithErrorFilter(t, func(s string) bool {
 		expectedError := strings.Contains(s, "no response or bad StatusCode") ||
 			strings.Contains(s, "Can't decode body: invalid character '}'") ||
-			strings.Contains(s, "connection refused")
+			strings.Contains(s, "connection refused") ||
+			strings.Contains(s, "No connection could be made because the target machine actively refused it")
 		return !expectedError
 	})
 	ctx, _ := inslogger.InitNodeLoggerByGlobal("", "")

--- a/ledger-core/application/api/availability_test.go
+++ b/ledger-core/application/api/availability_test.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -39,7 +40,12 @@ func waitForStatus(t *testing.T, nc *api.NetworkChecker, expected bool) {
 }
 
 func TestAvailabilityChecker_UpdateStatus(t *testing.T) {
-	instestlogger.SetTestOutputWithIgnoreAllErrors(t)
+	instestlogger.SetTestOutputWithErrorFilter(t, func(s string) bool {
+		expectedError := strings.Contains(s, "no response or bad StatusCode") ||
+			strings.Contains(s, "Can't decode body: invalid character '}'") ||
+			strings.Contains(s, "connection refused")
+		return !expectedError
+	})
 	ctx, _ := inslogger.InitNodeLoggerByGlobal("", "")
 
 	defer testutils.LeakTester(t,

--- a/ledger-core/application/api/seed_test.go
+++ b/ledger-core/application/api/seed_test.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"errors"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/gojuno/minimock/v3"
@@ -28,7 +29,9 @@ func TestNodeService_GetSeed(t *testing.T) {
 	defer testutils.LeakTester(t,
 		goleak.IgnoreTopFunction("github.com/insolar/assured-ledger/ledger-core/application/api/seedmanager.NewSpecified.func1"))
 
-	instestlogger.SetTestOutputWithIgnoreAllErrors(t)
+	instestlogger.SetTestOutputWithErrorFilter(t, func(s string) bool {
+		return !strings.Contains(s, "fake error")
+	})
 
 	availableFlag := false
 	mc := minimock.NewController(t)

--- a/ledger-core/network/hostnetwork/hostnetwork_test.go
+++ b/ledger-core/network/hostnetwork/hostnetwork_test.go
@@ -7,6 +7,7 @@ package hostnetwork
 
 import (
 	"context"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -286,7 +287,9 @@ func TestHostNetwork_SendRequestPacket3(t *testing.T) {
 }
 
 func TestHostNetwork_SendRequestPacket_errors(t *testing.T) {
-	instestlogger.SetTestOutput(t)
+	instestlogger.SetTestOutputWithErrorFilter(t, func(s string) bool {
+		return !strings.Contains(s, "Failed to send response")
+	})
 	s := newHostSuite(t)
 	defer s.Stop()
 

--- a/ledger-core/network/integration/suite_test.go
+++ b/ledger-core/network/integration/suite_test.go
@@ -58,10 +58,10 @@ const (
 	UseFakeTransport = false
 	UseFakeBootstrap = true
 
-	reqTimeoutMs		= 2000
-	pulseDelta			= 4
-//	consensusMin		= 5 // minimum count of participants that can survive when one node leaves
-	maxPulsesForJoin	= 3
+	reqTimeoutMs = 2000
+	pulseDelta   = 4
+	//	consensusMin		= 5 // minimum count of participants that can survive when one node leaves
+	maxPulsesForJoin = 3
 )
 
 const cacheDir = "network_cache/"
@@ -569,7 +569,7 @@ func (s *testSuite) preInitNode(node *networkNode) {
 		keystore.NewInplaceKeyStore(node.privateKey),
 		serviceNetwork,
 		keyProc,
-//		testutils.NewContractRequesterMock(s.t),
+		//		testutils.NewContractRequesterMock(s.t),
 	)
 	node.serviceNetwork = serviceNetwork
 

--- a/ledger-core/network/servicenetwork/servicenetwork_test.go
+++ b/ledger-core/network/servicenetwork/servicenetwork_test.go
@@ -7,6 +7,7 @@ package servicenetwork
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/ThreeDotsLabs/watermill"
@@ -47,8 +48,6 @@ func (p *PublisherMock) Close() error {
 }
 
 func prepareNetwork(t *testing.T, cfg configuration.Configuration) *ServiceNetwork {
-	instestlogger.SetTestOutputWithIgnoreAllErrors(t)
-
 	serviceNetwork, err := NewServiceNetwork(cfg, component.NewManager(nil))
 	require.NoError(t, err)
 
@@ -63,6 +62,12 @@ func prepareNetwork(t *testing.T, cfg configuration.Configuration) *ServiceNetwo
 
 func TestSendMessageHandler_ReceiverNotSet(t *testing.T) {
 	cfg := configuration.NewConfiguration()
+	instestlogger.SetTestOutputWithErrorFilter(t, func(s string) bool {
+		if strings.Contains(s, "failed to send message: Receiver in message metadata is not set") {
+			return false
+		}
+		return true
+	})
 
 	serviceNetwork := prepareNetwork(t, cfg)
 

--- a/ledger-core/network/servicenetwork/servicenetwork_test.go
+++ b/ledger-core/network/servicenetwork/servicenetwork_test.go
@@ -264,6 +264,12 @@ func (pm *publisherMock) Publish(topic string, messages ...*message.Message) err
 func (pm *publisherMock) Close() error                                             { return nil }
 
 func TestServiceNetwork_processIncoming(t *testing.T) {
+	instestlogger.SetTestOutputWithErrorFilter(t, func(s string) bool {
+		expectedError := strings.Contains(s, "error while deserialize msg from buffer") ||
+			strings.Contains(s, "error while publish msg to TopicIncoming")
+		return !expectedError
+	})
+
 	serviceNetwork, err := NewServiceNetwork(configuration.NewConfiguration(), component.NewManager(nil))
 	require.NoError(t, err)
 	pub := &publisherMock{}

--- a/ledger-core/server/internal/headless/components_test.go
+++ b/ledger-core/server/internal/headless/components_test.go
@@ -22,7 +22,7 @@ import (
 
 func TestComponents(t *testing.T) {
 	instestlogger.SetTestOutputWithErrorFilter(t, func(s string) bool {
-		if strings.Contains(s, "Failed to export to Prometheus: cannot register the collector: duplicate metrics collector registration attempted") {
+		if strings.Contains(s, "Failed to export to Prometheus: cannot register the collector:") {
 			return false
 		}
 		return true

--- a/ledger-core/server/internal/headless/components_test.go
+++ b/ledger-core/server/internal/headless/components_test.go
@@ -9,6 +9,7 @@ package headless
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -20,7 +21,12 @@ import (
 )
 
 func TestComponents(t *testing.T) {
-	instestlogger.SetTestOutputWithIgnoreAllErrors(t)
+	instestlogger.SetTestOutputWithErrorFilter(t, func(s string) bool {
+		if strings.Contains(s, "Failed to export to Prometheus: cannot register the collector: duplicate metrics collector registration attempted") {
+			return false
+		}
+		return true
+	})
 
 	ctx := inslogger.UpdateLogger(context.Background(), func(logger log.Logger) (log.Logger, error) {
 		return logger.Copy().WithBuffer(100, false).Build()

--- a/ledger-core/server/internal/headless/components_test.go
+++ b/ledger-core/server/internal/headless/components_test.go
@@ -22,10 +22,7 @@ import (
 
 func TestComponents(t *testing.T) {
 	instestlogger.SetTestOutputWithErrorFilter(t, func(s string) bool {
-		if strings.Contains(s, "Failed to export to Prometheus: cannot register the collector:") {
-			return false
-		}
-		return true
+		return !strings.Contains(s, "Failed to export to Prometheus: cannot register the collector")
 	})
 
 	ctx := inslogger.UpdateLogger(context.Background(), func(logger log.Logger) (log.Logger, error) {

--- a/ledger-core/server/internal/virtual/components_test.go
+++ b/ledger-core/server/internal/virtual/components_test.go
@@ -7,6 +7,7 @@ package virtual
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -18,7 +19,12 @@ import (
 )
 
 func TestComponents(t *testing.T) {
-	instestlogger.SetTestOutputWithIgnoreAllErrors(t)
+	instestlogger.SetTestOutputWithErrorFilter(t, func(s string) bool {
+		if strings.Contains(s, "Failed to export to Prometheus: cannot register the collector: duplicate metrics collector registration attempted") {
+			return false
+		}
+		return true
+	})
 
 	ctx := inslogger.UpdateLogger(context.Background(), func(logger log.Logger) (log.Logger, error) {
 		return logger.Copy().WithBuffer(100, false).Build()

--- a/ledger-core/server/internal/virtual/components_test.go
+++ b/ledger-core/server/internal/virtual/components_test.go
@@ -20,10 +20,7 @@ import (
 
 func TestComponents(t *testing.T) {
 	instestlogger.SetTestOutputWithErrorFilter(t, func(s string) bool {
-		if strings.Contains(s, "Failed to export to Prometheus: cannot register the collector: duplicate metrics collector registration attempted") {
-			return false
-		}
-		return true
+		return !strings.Contains(s, "Failed to export to Prometheus: cannot register the collector")
 	})
 
 	ctx := inslogger.UpdateLogger(context.Background(), func(logger log.Logger) (log.Logger, error) {

--- a/ledger-core/virtual/integration/delegated_finished_test.go
+++ b/ledger-core/virtual/integration/delegated_finished_test.go
@@ -85,7 +85,7 @@ func TestVirtual_SendDelegatedFinished_IfPulseChanged_WithSideEffect(t *testing.
 		mc = minimock.NewController(t)
 	)
 
-	server, ctx := utils.NewUninitializedServer(nil, t) // TODO PLAT-367 fix test to be stable and have no errors in logs
+	server, ctx := utils.NewUninitializedServer(nil, t)
 	defer server.Stop()
 
 	runnerMock := logicless.NewServiceMock(ctx, mc, nil)


### PR DESCRIPTION
The only place that still holds IgnoreError are network integration tests, which would be reworked