### PR TITLE
PLAT-641: constructor can run on missing state, update correctly

### DIFF
--- a/ledger-core/virtual/execute/execute.go
+++ b/ledger-core/virtual/execute/execute.go
@@ -762,8 +762,13 @@ func (s *SMExecute) stepSaveNewObject(ctx smachine.ExecutionContext) smachine.St
 	action := func(state *object.SharedState) {
 		state.Info.SetDescriptor(s.newObjectDescriptor)
 
-		if state.GetState() == object.Empty {
+		switch state.GetState() {
+		case object.HasState:
+			// ok
+		case object.Empty, object.Missing:
 			state.SetState(object.HasState)
+		default:
+			panic(throw.IllegalState())
 		}
 	}
 


### PR DESCRIPTION
requests on objects that don't exist or don't yet exist cause
StateReport to be send with Missing state. Such StateReport is caused by
constructor that hit SMExecute, but didn't reach execution before pulse
change. Constructor is retried in the new pulse and is excuted on
Missing state.