### PR TITLE
[Merged by Bors] - Rename test case C4930 to C5094

### DIFF
--- a/ledger-core/virtual/integration/method_test.go
+++ b/ledger-core/virtual/integration/method_test.go
@@ -232,7 +232,7 @@ func TestVirtual_Method_WithExecutor_ObjectIsNotExist(t *testing.T) {
 }
 
 func TestVirtual_Method_WithoutExecutor_Unordered(t *testing.T) {
-	t.Log("C4930")
+	t.Log("C5094")
 
 	mc := minimock.NewController(t)
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
There were two duplicated test cases, C4930 and C5094 in the testrail. C4930 had implemented test in the code but the test case was put in the wrong section in testrail. I should have moved it to the right section and removed C5094, but I didn't know that id of the test case cannot be changed and removed C4930 instead. Now it's easier just to change test case id in the code so that it corresponds to the test case id in the testrail (C5094).

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
