### PR TITLE
PLAT-635: add messages debug logging

### DIFF
--- a/ledger-core/insolar/payload/marshaler.go
+++ b/ledger-core/insolar/payload/marshaler.go
@@ -7,6 +7,7 @@ package payload
 
 type Marshaler interface {
 	Marshal() ([]byte, error)
+	String() string
 	// Temporary commented to look like insolar.Payload
 	//MarshalHead() ([]byte, error)
 	//MarshalContent() ([]byte, error)

--- a/ledger-core/insolar/payload/message.go
+++ b/ledger-core/insolar/payload/message.go
@@ -15,7 +15,11 @@ func NewMessage(pl Marshaler) (*message.Message, error) {
 	if err != nil {
 		return nil, err
 	}
-	return message.NewMessage(watermill.NewUUID(), buf), nil
+
+	msg := message.NewMessage(watermill.NewUUID(), buf)
+	// for debug logging only!
+	msg.Metadata.Set("payload_string", pl.String())
+	return msg, nil
 }
 
 func MustNewMessage(pl Marshaler) *message.Message {

--- a/ledger-core/network/messagesender/service.go
+++ b/ledger-core/network/messagesender/service.go
@@ -111,8 +111,8 @@ func (dm *DefaultService) sendTarget(
 		inslogger.FromContext(ctx).Warn(throw.W(err, "failed to fetch pulse"))
 	}
 
-
-	ctx, logger := inslogger.WithField(ctx, "sending_uuid", msg.UUID)
+	ctx, logTmp := inslogger.WithField(ctx, "sending_uuid", msg.UUID)
+	logger := logTmp.WithField("metadata", msg.Metadata)
 
 	msg.Metadata.Set(defaults.TraceID, inslogger.TraceID(ctx))
 	sp, err := instracer.Serialize(ctx)


### PR DESCRIPTION
Debug log example:
```
2020-07-09T17:04:35.808368000+03:00 DBG sending message caller=network/messagesender/service.go:132 loginstance=node metadata={"payload_string":"CallType:CTMethod CallFlags:9 Caller:\u003cinsolar:0AAABAnRB0CKuqXTeTfQNTolmyixqQGMJz5sVvW81Dng\u003e Callee:\u003cinsolar:1At12c8PEcRuvJnbh8kW6Xio4d6D80SM8KVYLJQAAADg.0AAABAnRB0CKuqXTeTfQNTolmyixqQGMJz5sVvW81Dng\u003e CallSiteDeclaration:\u003cinsolar:0\u003e CallSiteMethod:\"GetBalance\" CallReason:\u003cinsolar:0\u003e RootTX:\u003cinsolar:0\u003e CallTX:\u003cinsolar:0\u003e ExpenseCenter:\u003cinsolar:0\u003e ResourceCenter:\u003cinsolar:0\u003e DelegationSpec:\u003cTokenTypeAndFlags:0 Approver:\u003cinsolar:0\u003e DelegateTo:\u003cinsolar:0\u003e Callee:\u003cinsolar:0\u003e Caller:\u003cinsolar:0\u003e Outgoing:\u003cinsolar:0\u003e \u003e RegistrarDelegationSpec:\u003cTokenTypeAndFlags:0 Approver:\u003cinsolar:0\u003e DelegateTo:\u003cinsolar:0\u003e Callee:\u003cinsolar:0\u003e Caller:\u003cinsolar:0\u003e Outgoing:\u003cinsolar:0\u003e \u003e KnownCalleeIncoming:\u003cinsolar:0\u003e CallOutgoing:\u003cinsolar:1At12cz3lUEQ-PqSfvUv4vCunDn3RK2Gm7IgQCwAAADI.0AAABAnRB0CKuqXTeTfQNTolmyixqQGMJz5sVvW81Dng\u003e Arguments:\"\\200\" "} nodeid=insolar:1AAEAAcky-HbDAm1u__dP6rIdMUpJmFLrw0VHumgezsg role=virtual sending_uuid=2fd5bcc8-ab83-4999-bcf5-ab733237730f traceid=0842469bc774793408dbd7196b259ba8 writeDuration="6.000µs"
```