### PR TITLE
[Merged by Bors] - PLAT-633: Fixed Object ref in SMExecute if called constructor 

### DIFF
--- a/ledger-core/virtual/execute/delegatedtokenrequest_test.go
+++ b/ledger-core/virtual/execute/delegatedtokenrequest_test.go
@@ -41,10 +41,11 @@ func TestVDelegatedCallRequest(t *testing.T) {
 	slotMachine.PrepareMockedMessageSender(mc)
 
 	var (
-		caller       = gen.UniqueGlobalRef()
-		callee       = gen.UniqueGlobalRef()
-		objectGlobal = reference.NewRecordOf(caller, slotMachine.GenerateLocal())
-		tokenKey     = DelegationTokenAwaitKey{objectGlobal}
+		caller    = gen.UniqueGlobalRef()
+		callee    = gen.UniqueGlobalRef()
+		outgoing  = reference.NewRecordOf(caller, slotMachine.GenerateLocal())
+		objectRef = reference.NewSelf(outgoing.GetLocal())
+		tokenKey  = DelegationTokenAwaitKey{outgoing}
 
 		migrationPulse pulse.Number
 
@@ -52,7 +53,7 @@ func TestVDelegatedCallRequest(t *testing.T) {
 			Payload: &payload.VCallRequest{
 				CallType:     payload.CTConstructor,
 				CallFlags:    payload.BuildCallFlags(contract.CallTolerable, contract.CallDirty),
-				CallOutgoing: objectGlobal,
+				CallOutgoing: outgoing,
 
 				Caller: caller,
 				Callee: callee,
@@ -71,7 +72,7 @@ func TestVDelegatedCallRequest(t *testing.T) {
 
 		sharedStateData := smachine.NewUnboundSharedData(&object.SharedState{
 			Info: object.Info{
-				Reference:      objectGlobal,
+				Reference:      objectRef,
 				PendingTable:   callregistry.NewRequestTable(),
 				KnownRequests:  callregistry.NewWorkingTable(),
 				ReadyToWork:    smsync.NewConditional(1, "ReadyToWork").SyncLink(),
@@ -81,7 +82,7 @@ func TestVDelegatedCallRequest(t *testing.T) {
 
 		smObjectAccessor := object.SharedStateAccessor{SharedDataLink: sharedStateData}
 
-		catalogWrapper.AddObject(objectGlobal, smObjectAccessor)
+		catalogWrapper.AddObject(objectRef, smObjectAccessor)
 		catalogWrapper.AllowAccessMode(object.CatalogMockAccessGetOrCreate)
 	}
 
@@ -90,21 +91,21 @@ func TestVDelegatedCallRequest(t *testing.T) {
 			res, ok := msg.(*payload.VDelegatedCallRequest)
 			require.True(t, ok)
 			require.NotNil(t, res)
-			require.Equal(t, objectGlobal, object)
+			require.Equal(t, objectRef, object)
 			require.Equal(t, migrationPulse, pn)
 			return nil
 		})
 
 	{
-		slotMachine.RunnerMock.AddExecutionClassify(objectGlobal.String(), contract.MethodIsolation{
+		slotMachine.RunnerMock.AddExecutionClassify(outgoing.String(), contract.MethodIsolation{
 			Interference: contract.CallTolerable,
 			State:        contract.CallDirty,
 		}, nil)
-		slotMachine.RunnerMock.AddExecutionMock(objectGlobal.String()).AddStart(
+		slotMachine.RunnerMock.AddExecutionMock(outgoing.String()).AddStart(
 			nil,
 			&execution.Update{
 				Type:   execution.Done,
-				Result: requestresult.New([]byte("123"), objectGlobal),
+				Result: requestresult.New([]byte("123"), outgoing),
 			})
 	}
 
@@ -125,7 +126,7 @@ func TestVDelegatedCallRequest(t *testing.T) {
 		require.False(t, slotLink.IsZero())
 
 		ok := bargeInHolder.CallWithParam(&payload.VDelegatedCallResponse{
-			ResponseDelegationSpec: payload.CallDelegationToken{Outgoing: objectGlobal},
+			ResponseDelegationSpec: payload.CallDelegationToken{Outgoing: outgoing},
 		})
 		require.True(t, ok)
 	}
@@ -134,7 +135,7 @@ func TestVDelegatedCallRequest(t *testing.T) {
 		slotMachine.RunTil(smWrapper.AfterStep(smExecute.stepAfterTokenGet.Transition))
 
 		require.NotNil(t, smExecute.delegationTokenSpec)
-		require.Equal(t, objectGlobal, smExecute.delegationTokenSpec.Outgoing)
+		require.Equal(t, outgoing, smExecute.delegationTokenSpec.Outgoing)
 	}
 
 	{

--- a/ledger-core/virtual/execute/execute.go
+++ b/ledger-core/virtual/execute/execute.go
@@ -114,7 +114,7 @@ func (s *SMExecute) prepareExecution(ctx context.Context) {
 
 	if s.Payload.CallType == payload.CTConstructor {
 		s.isConstructor = true
-		s.execution.Object = s.Payload.CallOutgoing
+		s.execution.Object = reference.NewSelf(s.Payload.CallOutgoing.GetLocal())
 	} else {
 		s.execution.Object = s.Payload.Callee
 	}

--- a/ledger-core/virtual/execute/execute_publish_callsummary_test.go
+++ b/ledger-core/virtual/execute/execute_publish_callsummary_test.go
@@ -78,9 +78,11 @@ func TestSMExecute_PublishVCallResultToCallSummarySM(t *testing.T) {
 	}
 
 	{
+		outgoingRef = reference.NewSelf(outgoingRef.GetLocal())
+
 		workingTable := callregistry.NewWorkingTable()
-		workingTable.Add(contract.CallTolerable, outgoingRef)
-		workingTable.SetActive(contract.CallTolerable, outgoingRef)
+		workingTable.Add(contract.CallTolerable, smExecute.execution.Outgoing)
+		workingTable.SetActive(contract.CallTolerable, smExecute.execution.Outgoing)
 
 		sharedCallSummary.Requests.AddObjectCallResults(outgoingRef, callregistry.ObjectCallResults{
 			CallResults: workingTable.GetResults(),
@@ -135,7 +137,7 @@ func TestSMExecute_PublishVCallResultToCallSummarySM(t *testing.T) {
 	workingTable, ok := sharedCallSummary.Requests.GetObjectCallResults(outgoingRef)
 	require.Equal(t, 1, len(workingTable.CallResults))
 
-	result, ok := workingTable.CallResults[outgoingRef]
+	result, ok := workingTable.CallResults[smExecute.execution.Outgoing]
 
 	require.True(t, ok)
 	require.NotNil(t, result.Result)

--- a/ledger-core/virtual/execute/execute_semiintegration_test.go
+++ b/ledger-core/virtual/execute/execute_semiintegration_test.go
@@ -47,6 +47,7 @@ func TestSMExecute_Semi_IncrementPendingCounters(t *testing.T) {
 	slotMachine.PrepareRunner(ctx, mc)
 
 	outgoing := reference.NewRecordOf(caller, slotMachine.GenerateLocal())
+	objectRef := reference.NewSelf(outgoing.GetLocal())
 
 	smExecute := SMExecute{
 		Payload: &payload.VCallRequest{
@@ -75,7 +76,7 @@ func TestSMExecute_Semi_IncrementPendingCounters(t *testing.T) {
 		sharedStateData := smachine.NewUnboundSharedData(sharedState)
 		smObjectAccessor := object.SharedStateAccessor{SharedDataLink: sharedStateData}
 
-		catalogWrapper.AddObject(outgoing, smObjectAccessor)
+		catalogWrapper.AddObject(objectRef, smObjectAccessor)
 		catalogWrapper.AllowAccessMode(object.CatalogMockAccessGetOrCreate)
 	}
 
@@ -119,6 +120,7 @@ func TestSMExecute_MigrateBeforeLock(t *testing.T) {
 	slotMachine.PrepareRunner(ctx, mc)
 
 	outgoing := reference.NewRecordOf(caller, slotMachine.GenerateLocal())
+	objectRef := reference.NewSelf(outgoing.GetLocal())
 
 	smExecute := SMExecute{
 		Payload: &payload.VCallRequest{
@@ -147,7 +149,7 @@ func TestSMExecute_MigrateBeforeLock(t *testing.T) {
 		sharedStateData := smachine.NewUnboundSharedData(sharedState)
 		smObjectAccessor := object.SharedStateAccessor{SharedDataLink: sharedStateData}
 
-		catalogWrapper.AddObject(outgoing, smObjectAccessor)
+		catalogWrapper.AddObject(objectRef, smObjectAccessor)
 		catalogWrapper.AllowAccessMode(object.CatalogMockAccessGetOrCreate)
 	}
 
@@ -192,6 +194,7 @@ func TestSMExecute_MigrateAfterLock(t *testing.T) {
 	slotMachine.PrepareRunner(ctx, mc)
 
 	outgoing := reference.NewRecordOf(caller, slotMachine.GenerateLocal())
+	objectRef := reference.NewSelf(outgoing.GetLocal())
 
 	smExecute := SMExecute{
 		Payload: &payload.VCallRequest{
@@ -220,7 +223,7 @@ func TestSMExecute_MigrateAfterLock(t *testing.T) {
 		sharedStateData := smachine.NewUnboundSharedData(sharedState)
 		smObjectAccessor := object.SharedStateAccessor{SharedDataLink: sharedStateData}
 
-		catalogWrapper.AddObject(outgoing, smObjectAccessor)
+		catalogWrapper.AddObject(objectRef, smObjectAccessor)
 		catalogWrapper.AllowAccessMode(object.CatalogMockAccessGetOrCreate)
 	}
 
@@ -257,6 +260,7 @@ func TestSMExecute_Semi_ConstructorOnMissingObject(t *testing.T) {
 		class       = gen.UniqueGlobalRef()
 		caller      = gen.UniqueGlobalRef()
 		outgoing    = reference.NewRecordOf(caller, slotMachine.GenerateLocal())
+		objectRef   = reference.NewSelf(outgoing.GetLocal())
 		sharedState = &object.SharedState{
 			Info: object.Info{
 				PendingTable:   callregistry.NewRequestTable(),
@@ -296,7 +300,7 @@ func TestSMExecute_Semi_ConstructorOnMissingObject(t *testing.T) {
 		sharedStateData := smachine.NewUnboundSharedData(sharedState)
 		smObjectAccessor := object.SharedStateAccessor{SharedDataLink: sharedStateData}
 
-		catalogWrapper.AddObject(outgoing, smObjectAccessor)
+		catalogWrapper.AddObject(objectRef, smObjectAccessor)
 		catalogWrapper.AllowAccessMode(object.CatalogMockAccessGetOrCreate)
 	}
 
@@ -331,6 +335,7 @@ func TestSMExecute_Semi_ConstructorOnBadObject(t *testing.T) {
 		class       = gen.UniqueGlobalRef()
 		caller      = gen.UniqueGlobalRef()
 		outgoing    = reference.NewRecordOf(caller, slotMachine.GenerateLocal())
+		objectRef   = reference.NewSelf(outgoing.GetLocal())
 		sharedState = &object.SharedState{
 			Info: object.Info{
 				PendingTable:   callregistry.NewRequestTable(),
@@ -370,7 +375,7 @@ func TestSMExecute_Semi_ConstructorOnBadObject(t *testing.T) {
 		sharedStateData := smachine.NewUnboundSharedData(sharedState)
 		smObjectAccessor := object.SharedStateAccessor{SharedDataLink: sharedStateData}
 
-		catalogWrapper.AddObject(outgoing, smObjectAccessor)
+		catalogWrapper.AddObject(objectRef, smObjectAccessor)
 		catalogWrapper.AllowAccessMode(object.CatalogMockAccessGetOrCreate)
 	}
 

--- a/ledger-core/virtual/execute/execute_test.go
+++ b/ledger-core/virtual/execute/execute_test.go
@@ -51,7 +51,7 @@ func expectedInitState(ctx context.Context, sm SMExecute) SMExecute {
 
 	if sm.Payload.CallType == payload.CTConstructor {
 		sm.isConstructor = true
-		sm.execution.Object = sm.Payload.CallOutgoing
+		sm.execution.Object = reference.NewSelf(sm.Payload.CallOutgoing.GetLocal())
 	} else {
 		sm.execution.Object = sm.Payload.Callee
 	}
@@ -770,7 +770,7 @@ func TestSendVStateReportWithMissingState_IfConstructorWasInterruptedBeforeRunne
 		res, ok := msg.(*payload.VStateReport)
 		require.True(t, ok)
 		assert.Equal(t, payload.Missing, res.Status)
-		assert.Equal(t, outgoing, res.Object)
+		assert.Equal(t, reference.NewSelf(outgoing.GetLocal()), res.Object)
 		assert.Equal(t, int32(0), res.OrderedPendingCount)
 		assert.Equal(t, int32(0), res.UnorderedPendingCount)
 		assert.Empty(t, res.LatestDirtyState)

--- a/ledger-core/virtual/integration/contract_calls_test.go
+++ b/ledger-core/virtual/integration/contract_calls_test.go
@@ -396,7 +396,7 @@ func TestVirtual_CallMethodFromConstructor(t *testing.T) {
 
 				classA        = gen.UniqueGlobalRef()
 				outgoingA     = server.BuildRandomOutgoingWithPulse()
-				objectAGlobal = outgoingA
+				objectAGlobal = reference.NewSelf(outgoingA.GetLocal())
 
 				classB        = gen.UniqueGlobalRef()
 				objectBGlobal = reference.NewSelf(server.RandomLocalWithPulse())

--- a/ledger-core/virtual/integration/deduplication/constructor_test.go
+++ b/ledger-core/virtual/integration/deduplication/constructor_test.go
@@ -246,7 +246,7 @@ func (test *DeduplicationDifferentPulsesCase) run(t *testing.T) {
 		previousPulse = test.Server.GetPulse().PulseNumber
 		outgoingLocal = gen.UniqueLocalRefWithPulse(previousPulse)
 		outgoing      = reference.NewRecordOf(test.Server.GlobalCaller(), outgoingLocal)
-		object        = outgoing
+		object        = reference.NewSelf(outgoingLocal)
 		executeDone   = test.Server.Journal.WaitStopOf(&execute.SMExecute{}, 1)
 		foundError    = synckit.ClosedChannel()
 
@@ -270,7 +270,7 @@ func (test *DeduplicationDifferentPulsesCase) run(t *testing.T) {
 
 	// populate needed VFindCallResponse fields
 	if test.VFindCall != nil {
-		test.VFindCall.Callee = outgoing
+		test.VFindCall.Callee = object
 		test.VFindCall.Outgoing = outgoing
 	}
 
@@ -281,13 +281,13 @@ func (test *DeduplicationDifferentPulsesCase) run(t *testing.T) {
 		} else {
 			test.VDelegatedCall.CallOutgoing = outgoing
 		}
-		test.VDelegatedCall.Callee = outgoing
+		test.VDelegatedCall.Callee = object
 		test.VDelegatedCall.CallFlags = payload.BuildCallFlags(isolation.Interference, isolation.State)
 	}
 
 	if test.VDelegatedRequestFinished != nil {
 		test.VDelegatedRequestFinished.CallOutgoing = outgoing
-		test.VDelegatedRequestFinished.Callee = outgoing
+		test.VDelegatedRequestFinished.Callee = object
 		test.VDelegatedRequestFinished.CallFlags = payload.BuildCallFlags(isolation.Interference, isolation.State)
 	}
 

--- a/ledger-core/virtual/integration/deduplication/find_call_request_handler_test.go
+++ b/ledger-core/virtual/integration/deduplication/find_call_request_handler_test.go
@@ -351,7 +351,7 @@ func (s *VFindCallRequestHandlingSuite) generateCaller() {
 
 func (s *VFindCallRequestHandlingSuite) generateObjectRef() {
 	if s.isConstructor {
-		s.object = reference.NewRecordOf(s.caller, s.outgoing)
+		s.object = reference.NewSelf(s.outgoing)
 		return
 	}
 	p := s.getP1()

--- a/ledger-core/virtual/integration/outgoing_test.go
+++ b/ledger-core/virtual/integration/outgoing_test.go
@@ -313,8 +313,9 @@ func TestVirtual_CallConstructorOutgoing_WithTwicePulseChange(t *testing.T) {
 			State:        contract.CallDirty,
 		}
 
-		classA   = gen.UniqueGlobalRef()
-		outgoing = server.BuildRandomOutgoingWithPulse()
+		classA    = gen.UniqueGlobalRef()
+		outgoing  = server.BuildRandomOutgoingWithPulse()
+		objectRef = reference.NewSelf(outgoing.GetLocal())
 
 		outgoingCallRef = gen.UniqueGlobalRef()
 
@@ -376,13 +377,13 @@ func TestVirtual_CallConstructorOutgoing_WithTwicePulseChange(t *testing.T) {
 	{
 		typedChecker.VStateReport.Set(func(report *payload.VStateReport) bool {
 			// check for pending counts must be in tests: call constructor/call terminal method
-			assert.Equal(t, outgoing, report.Object)
+			assert.Equal(t, objectRef, report.Object)
 			assert.Equal(t, payload.Empty, report.Status)
 			assert.Zero(t, report.DelegationSpec)
 			return false
 		})
 		typedChecker.VDelegatedCallRequest.Set(func(request *payload.VDelegatedCallRequest) bool {
-			assert.Equal(t, outgoing, request.Callee)
+			assert.Equal(t, objectRef, request.Callee)
 			assert.Equal(t, outgoing, request.CallOutgoing)
 
 			msg := payload.VDelegatedCallResponse{Callee: request.Callee}
@@ -419,7 +420,7 @@ func TestVirtual_CallConstructorOutgoing_WithTwicePulseChange(t *testing.T) {
 			return false
 		})
 		typedChecker.VDelegatedRequestFinished.Set(func(finished *payload.VDelegatedRequestFinished) bool {
-			assert.Equal(t, outgoing, finished.Callee)
+			assert.Equal(t, objectRef, finished.Callee)
 			assert.Equal(t, secondExpectedToken, finished.DelegationSpec)
 			return false
 		})
@@ -457,7 +458,7 @@ func TestVirtual_CallConstructorOutgoing_WithTwicePulseChange(t *testing.T) {
 			return false
 		})
 		typedChecker.VCallResult.Set(func(res *payload.VCallResult) bool {
-			assert.Equal(t, outgoing, res.Callee)
+			assert.Equal(t, objectRef, res.Callee)
 			assert.Equal(t, []byte("finish A.New"), res.ReturnArguments)
 			assert.Equal(t, int(firstPulse), int(res.CallOutgoing.GetLocal().Pulse()))
 			assert.Equal(t, secondExpectedToken, res.DelegationSpec)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
`s.execution.Object = s.Payload.CallOutgoing` -> `s.execution.Object = reference.NewSelf(s.Payload.CallOutgoing.GetLocal())` in SMExecute.prepareExecution

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

https://insolar.atlassian.net/browse/PLAT-633
