### PR TITLE
PLAT-644: even if we can not copy logger, we can re-use output

### DIFF
--- a/ledger-core/log/builder.go
+++ b/ledger-core/log/builder.go
@@ -268,6 +268,7 @@ func (z LoggerBuilder) buildEmbedded(needsLowLatency bool) (logcommon.EmbeddedLo
 				if logger := template.CopyTemplateLogger(params); logger != nil {
 					return logger, nil
 				}
+				output = origConfig.LoggerOutput
 			}
 			break
 		}


### PR DESCRIPTION
if we don't re-use then every call to inslogger.Clean creates a new
output with BackPressureBuffer that has a goroutine that stays forever
and is quite heavy.
