### PR TITLE
NOISSUE: use object reference as publishing key for object's shared data

### DIFF
--- a/ledger-core/virtual/object/catalog.go
+++ b/ledger-core/virtual/object/catalog.go
@@ -50,7 +50,7 @@ func (p LocalCatalog) Get(ctx smachine.ExecutionContext, objectReference referen
 }
 
 func (p LocalCatalog) TryGet(ctx smachine.ExecutionContext, objectReference reference.Global) (SharedStateAccessor, bool) { // nolintcontractrequester/contractrequester.go:342
-	if v := ctx.GetPublishedLink(objectReference.String()); v.IsAssignableTo((*SharedState)(nil)) {
+	if v := ctx.GetPublishedLink(objectReference); v.IsAssignableTo((*SharedState)(nil)) {
 		return SharedStateAccessor{v}, true
 	}
 	return SharedStateAccessor{}, false

--- a/ledger-core/virtual/object/object.go
+++ b/ledger-core/virtual/object/object.go
@@ -259,7 +259,7 @@ func (sm *SMObject) Init(ctx smachine.InitializationContext) smachine.StateUpdat
 	sm.OrderedExecute = sm.orderedSemaphoreCtl.SyncLink()
 
 	sdl := ctx.Share(&sm.SharedState, 0)
-	if !ctx.Publish(sm.Reference.String(), sdl) {
+	if !ctx.Publish(sm.Reference, sdl) {
 		return ctx.Stop()
 	}
 

--- a/ledger-core/virtual/object/object_migration_test.go
+++ b/ledger-core/virtual/object/object_migration_test.go
@@ -39,7 +39,7 @@ func TestSMObject_InitSetMigration(t *testing.T) {
 	}
 	initCtx := smachine.NewInitializationContextMock(mc).
 		ShareMock.Return(sharedStateData).
-		PublishMock.Expect(smObject.Reference.String(), sharedStateData).Return(true).
+		PublishMock.Expect(smObject.Reference, sharedStateData).Return(true).
 		JumpMock.Return(smachine.StateUpdate{}).
 		SetDefaultMigrationMock.Set(compareDefaultMigration)
 

--- a/ledger-core/virtual/object/object_publish_callsummary_test.go
+++ b/ledger-core/virtual/object/object_publish_callsummary_test.go
@@ -56,7 +56,7 @@ func TestSMObject_CallSummarySM(t *testing.T) {
 	{
 		initCtx := smachine.NewInitializationContextMock(mc).
 			ShareMock.Return(sharedStateData).
-			PublishMock.Expect(smObject.Reference.String(), sharedStateData).Return(true).
+			PublishMock.Expect(smObject.Reference, sharedStateData).Return(true).
 			JumpMock.Return(smachine.StateUpdate{}).
 			SetDefaultMigrationMock.Set(func(m1 smachine.MigrateFunc) {
 

--- a/ledger-core/virtual/object/object_test.go
+++ b/ledger-core/virtual/object/object_test.go
@@ -49,7 +49,7 @@ func Test_Delay(t *testing.T) {
 	{ // initialization
 		initCtx := smachine.NewInitializationContextMock(mc).
 			ShareMock.Return(sharedStateData).
-			PublishMock.Expect(smObject.Reference.String(), sharedStateData).Return(true).
+			PublishMock.Expect(smObject.Reference, sharedStateData).Return(true).
 			JumpMock.Set(stepChecker.CheckJumpW(t)).
 			SetDefaultMigrationMock.Return()
 
@@ -137,7 +137,7 @@ func Test_PendingBlocksExecution(t *testing.T) {
 			{ // initialization
 				initCtx := smachine.NewInitializationContextMock(mc).
 					ShareMock.Return(sharedStateData).
-					PublishMock.Expect(smObject.Reference.String(), sharedStateData).Return(true).
+					PublishMock.Expect(smObject.Reference, sharedStateData).Return(true).
 					JumpMock.Set(stepChecker.CheckJumpW(t)).
 					SetDefaultMigrationMock.Return()
 
@@ -220,7 +220,7 @@ func TestSMObject_stepGotState_Set_PendingListFilled(t *testing.T) {
 	{ // initialization
 		initCtx := smachine.NewInitializationContextMock(mc).
 			ShareMock.Return(sharedStateData).
-			PublishMock.Expect(smObject.Reference.String(), sharedStateData).Return(true).
+			PublishMock.Expect(smObject.Reference, sharedStateData).Return(true).
 			JumpMock.Set(stepChecker.CheckJumpW(t)).
 			SetDefaultMigrationMock.Return()
 


### PR DESCRIPTION
Stringification of reference is way to slow for such purpose

In theory we can wrap reference into special struct, but in this case
I think that this is object's primary data and it's ok to use object's
reference directly.

