### PR TITLE
NOISSUE: benchmark GetBalance on TestWallet contract

### DIFF
--- a/ledger-core/virtual/integration/benchs/basic_test.go
+++ b/ledger-core/virtual/integration/benchs/basic_test.go
@@ -1,0 +1,81 @@
+package benchs
+
+import (
+	"testing"
+	"time"
+
+	"github.com/insolar/assured-ledger/ledger-core/application/builtin/contract/testwallet"
+	walletproxy "github.com/insolar/assured-ledger/ledger-core/application/builtin/proxy/testwallet"
+	"github.com/insolar/assured-ledger/ledger-core/insolar"
+	"github.com/insolar/assured-ledger/ledger-core/insolar/contract"
+	"github.com/insolar/assured-ledger/ledger-core/insolar/payload"
+	"github.com/insolar/assured-ledger/ledger-core/reference"
+	"github.com/insolar/assured-ledger/ledger-core/vanilla/synckit"
+	"github.com/insolar/assured-ledger/ledger-core/virtual/handlers"
+	"github.com/insolar/assured-ledger/ledger-core/virtual/integration/utils"
+	"github.com/insolar/assured-ledger/ledger-core/virtual/testutils"
+)
+
+func BenchmarkVCallRequestGetMethod(b *testing.B) {
+
+	server, ctx := utils.NewServer(nil, b)
+	defer server.Stop()
+	server.IncrementPulseAndWaitIdle(ctx)
+
+	var (
+		class  = walletproxy.GetClass()
+		object = reference.NewSelf(server.RandomLocalWithPulse())
+	)
+
+	walletMemory := insolar.MustSerialize(testwallet.Wallet{
+		Balance: 1234567,
+	})
+
+	content := &payload.VStateReport_ProvidedContentBody{
+		LatestDirtyState: &payload.ObjectState{
+			Reference: reference.Local{},
+			Class:     class,
+			State:     walletMemory,
+		},
+	}
+
+	report := &payload.VStateReport{
+		Status:          payload.Ready,
+		Object:          object,
+		ProvidedContent: content,
+	}
+
+	wait := server.Journal.WaitStopOf(&handlers.SMVStateReport{}, 1)
+	server.SendPayload(ctx, report)
+	testutils.WaitSignalsTimed(b, 10*time.Second, wait)
+
+	resultSignal := make(synckit.ClosableSignalChannel, 1)
+
+	typedChecker := server.PublisherMock.SetTypedChecker(ctx, b, server)
+	typedChecker.VCallResult.Set(func(result *payload.VCallResult) bool {
+		resultSignal <- struct{}{}
+		return false
+	})
+
+	pl := payload.VCallRequest{
+		CallType:            payload.CTMethod,
+		CallFlags:           payload.BuildCallFlags(contract.CallIntolerable, contract.CallDirty),
+		Caller:              server.GlobalCaller(),
+		Callee:              object,
+		CallSiteDeclaration: class,
+		CallSiteMethod:      "GetBalance",
+		Arguments:           insolar.MustSerialize([]interface{}{}),
+	}
+
+	b.StopTimer()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		pl.CallOutgoing = server.BuildRandomOutgoingWithPulse()
+		msg := server.WrapPayload(&pl).Finalize()
+
+		b.StartTimer()
+		server.SendMessage(ctx, msg)
+		testutils.WaitSignalsTimed(b, 10*time.Second, resultSignal)
+		b.StopTimer()
+	}
+}

--- a/ledger-core/virtual/integration/utils/server.go
+++ b/ledger-core/virtual/integration/utils/server.go
@@ -8,7 +8,6 @@ package utils
 import (
 	"context"
 	"sync"
-	"testing"
 
 	"github.com/ThreeDotsLabs/watermill/message"
 
@@ -79,23 +78,37 @@ type Server struct {
 
 type ConveyorCycleFunc func(c *conveyor.PulseConveyor, hasActive, isIdle bool)
 
-func NewServer(ctx context.Context, t *testing.T) (*Server, context.Context) {
+type Tester interface {
+
+	// logcommon.Logger+minimock.Tester
+
+	Helper()
+	Log(...interface{})
+
+	Fatal(args ...interface{})
+	Fatalf(format string, args ...interface{})
+	Error(...interface{})
+	Errorf(format string, args ...interface{})
+	FailNow()
+}
+
+func NewServer(ctx context.Context, t Tester) (*Server, context.Context) {
 	return newServerExt(ctx, t, nil, true)
 }
 
-func NewServerWithErrorFilter(ctx context.Context, t *testing.T, errorFilterFn logcommon.ErrorFilterFunc) (*Server, context.Context) {
+func NewServerWithErrorFilter(ctx context.Context, t Tester, errorFilterFn logcommon.ErrorFilterFunc) (*Server, context.Context) {
 	return newServerExt(ctx, t, errorFilterFn, true)
 }
 
-func NewUninitializedServer(ctx context.Context, t *testing.T) (*Server, context.Context) {
+func NewUninitializedServer(ctx context.Context, t Tester) (*Server, context.Context) {
 	return newServerExt(ctx, t, nil, false)
 }
 
-func NewUninitializedServerWithErrorFilter(ctx context.Context, t *testing.T, errorFilterFn logcommon.ErrorFilterFunc) (*Server, context.Context) {
+func NewUninitializedServerWithErrorFilter(ctx context.Context, t Tester, errorFilterFn logcommon.ErrorFilterFunc) (*Server, context.Context) {
 	return newServerExt(ctx, t, errorFilterFn, false)
 }
 
-func newServerExt(ctx context.Context, t *testing.T, errorFilterFn logcommon.ErrorFilterFunc, init bool) (*Server, context.Context) {
+func newServerExt(ctx context.Context, t Tester, errorFilterFn logcommon.ErrorFilterFunc, init bool) (*Server, context.Context) {
 	instestlogger.SetTestOutputWithErrorFilter(t, errorFilterFn)
 
 	if ctx == nil {

--- a/ledger-core/virtual/testutils/utils.go
+++ b/ledger-core/virtual/testutils/utils.go
@@ -6,7 +6,6 @@
 package testutils
 
 import (
-	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
@@ -18,10 +17,16 @@ func CmpStateFuncs(want, got interface{}) bool {
 	return reflectkit.CodeOf(want) == reflectkit.CodeOf(got)
 }
 
+type Tester interface {
+	Helper()
+	Errorf(format string, args ...interface{})
+	FailNow()
+}
+
 // WaitSignalsTimed waits with timeout for signal channels to be closed
 // or signaled with a message once. Waiting is ordered and not parallel,
 // this may be beneficial in some situation and hurtful in others.
-func WaitSignalsTimed(t *testing.T, timeout time.Duration, signals ...<-chan struct{}) {
+func WaitSignalsTimed(t Tester, timeout time.Duration, signals ...<-chan struct{}) {
 	t.Helper()
 
 	cleanUp := make(chan struct{})


### PR DESCRIPTION
benchmark includes VCallRequest processing without message
deserialization and with executor and contract code.

time between VCallRequest and VCallResult messages is timed.
Finalization of one request slightly overlaps with start of a new one.