### PR TITLE
NOISSUE: remove unnecessary Sprintf

### DIFF
--- a/ledger-core/application/testwalletapi/handlers.go
+++ b/ledger-core/application/testwalletapi/handlers.go
@@ -258,9 +258,7 @@ func (s *TestWalletServer) GetBalance(w http.ResponseWriter, req *http.Request) 
 	ref, err := reference.GlobalFromString(params.WalletRef)
 
 	if err != nil {
-		result.Error = throw.W(err,
-			fmt.Sprintf("Failed to create reference from string (%s)", params.WalletRef), nil,
-		).Error()
+		result.Error = throw.W(err, "Failed to create reference from string").Error()
 		return
 	}
 
@@ -338,9 +336,7 @@ func (s *TestWalletServer) AddAmount(w http.ResponseWriter, req *http.Request) {
 
 	ref, err := reference.GlobalFromString(params.To)
 	if err != nil {
-		result.Error = throw.W(err,
-			fmt.Sprintf("Failed to create reference from string (%s)", params.To), nil,
-		).Error()
+		result.Error = throw.W(err, "Failed to create reference from string").Error()
 
 		return
 	}
@@ -422,9 +418,7 @@ func (s *TestWalletServer) Delete(w http.ResponseWriter, req *http.Request) {
 	_, err = reference.GlobalFromString(params.WalletRef)
 
 	if err != nil {
-		result.Error = throw.W(err,
-			fmt.Sprintf("Failed to create reference from string (%s)", params.WalletRef), nil,
-		).Error()
+		result.Error = throw.W(err, "Failed to create reference from string").Error()
 		return
 	}
 


### PR DESCRIPTION
error contains all information:
```
$ curl -d '{ "walletRef": "insolar:1AuUjAIOV-8J7qVVi_a3FE" }'  "127.0.0.1:32304/wallet/delete" | jq
{
  "traceID": "a54a1928d58a75401447a13c105a7a9b",
  "error": "Failed to create reference from string;\tinvalid reference: ref=1AuUjAIOV-8J7qVVi_a3FE err=illegal base64 data at input byte 20"
}


$ curl -d '{ "walletRef": "insolar:1AuUjAIOV-8J7qVVi_a3FE" }'  "127.0.0.1:32304/wallet/get_balance" | jq
{
  "amount": 1000,
  "traceID": "f549b613f5ee88de6168a531220a56a9",
  "error": "Failed to create reference from string;\tinvalid reference: ref=1AuUjAIOV-8J7qVVi_a3FE err=illegal base64 data at input byte 20"
}
```