### PR TITLE
NOISSUE: old code was resulting in never stopping SM if it came to present pulse

### DIFF
--- a/ledger-core/virtual/handlers/vfindcallrequest.go
+++ b/ledger-core/virtual/handlers/vfindcallrequest.go
@@ -63,7 +63,6 @@ func (s *SMVFindCallRequest) GetStateMachineDeclaration() smachine.StateMachineD
 
 func (s *SMVFindCallRequest) Init(ctx smachine.InitializationContext) smachine.StateUpdate {
 	if s.pulseSlot.State() == conveyor.Present {
-		ctx.SetDefaultMigration(s.migrateFutureMessage)
 		return ctx.JumpExt(smachine.SlotStep{
 			Transition: s.stepWait,
 			Migration:  s.migrateFutureMessage,
@@ -78,12 +77,7 @@ func (s *SMVFindCallRequest) stepWait(ctx smachine.ExecutionContext) smachine.St
 }
 
 func (s *SMVFindCallRequest) migrateFutureMessage(ctx smachine.MigrationContext) smachine.StateUpdate {
-	return ctx.JumpExt(smachine.SlotStep{
-		Transition: s.stepProcessRequest,
-		Migration: func(ctx smachine.MigrationContext) smachine.StateUpdate {
-			return ctx.Stop()
-		},
-	})
+	return ctx.Jump(s.stepProcessRequest)
 }
 
 func (s *SMVFindCallRequest) stepProcessRequest(ctx smachine.ExecutionContext) smachine.StateUpdate {

--- a/ledger-core/virtual/integration/deduplication/find_call_request_handler_test.go
+++ b/ledger-core/virtual/integration/deduplication/find_call_request_handler_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/insolar/assured-ledger/ledger-core/vanilla/throw"
 	"github.com/insolar/assured-ledger/ledger-core/virtual/descriptor"
 	"github.com/insolar/assured-ledger/ledger-core/virtual/execute"
+	"github.com/insolar/assured-ledger/ledger-core/virtual/handlers"
 	"github.com/insolar/assured-ledger/ledger-core/virtual/integration/mock/publisher/checker"
 	"github.com/insolar/assured-ledger/ledger-core/virtual/integration/utils"
 	"github.com/insolar/assured-ledger/ledger-core/virtual/testutils"
@@ -154,6 +155,8 @@ func TestDeduplication_VFindCallRequestHandling(t *testing.T) {
 			ctx := suite.initServer(t)
 			defer suite.stopServer()
 
+			handlerEnded := suite.server.Journal.WaitStopOf(&handlers.SMVFindCallRequest{}, 1)
+
 			suite.initPulsesP1andP2(ctx)
 			suite.generateClass()
 			suite.generateCaller()
@@ -182,6 +185,7 @@ func TestDeduplication_VFindCallRequestHandling(t *testing.T) {
 			}
 
 			testutils.WaitSignalsTimed(t, 10*time.Second, suite.server.Journal.WaitAllAsyncCallsDone())
+			testutils.WaitSignalsTimed(t, 10*time.Second, handlerEnded)
 
 			suite.finish()
 		})


### PR DESCRIPTION
default migration is set to "jump(process)" and then never changed to
other

new code:
* default migration is Stop
* apply custom `jump(process)` migration only to stepWait using JumpExt

