### PR TITLE
NOISSUE: old code was setting default migration to special and never changed it

### DIFF
--- a/ledger-core/virtual/handlers/vfindcallrequest.go
+++ b/ledger-core/virtual/handlers/vfindcallrequest.go
@@ -63,7 +63,6 @@ func (s *SMVFindCallRequest) GetStateMachineDeclaration() smachine.StateMachineD
 
 func (s *SMVFindCallRequest) Init(ctx smachine.InitializationContext) smachine.StateUpdate {
 	if s.pulseSlot.State() == conveyor.Present {
-		ctx.SetDefaultMigration(s.migrateFutureMessage)
 		return ctx.JumpExt(smachine.SlotStep{
 			Transition: s.stepWait,
 			Migration:  s.migrateFutureMessage,
@@ -78,12 +77,7 @@ func (s *SMVFindCallRequest) stepWait(ctx smachine.ExecutionContext) smachine.St
 }
 
 func (s *SMVFindCallRequest) migrateFutureMessage(ctx smachine.MigrationContext) smachine.StateUpdate {
-	return ctx.JumpExt(smachine.SlotStep{
-		Transition: s.stepProcessRequest,
-		Migration: func(ctx smachine.MigrationContext) smachine.StateUpdate {
-			return ctx.Stop()
-		},
-	})
+	return ctx.Jump(s.stepProcessRequest)
 }
 
 func (s *SMVFindCallRequest) stepProcessRequest(ctx smachine.ExecutionContext) smachine.StateUpdate {

--- a/ledger-core/virtual/handlers/vfindcallrequest.plantuml
+++ b/ledger-core/virtual/handlers/vfindcallrequest.plantuml
@@ -3,44 +3,41 @@ state "Init" as T01_S001
 T01_S001 : SMVFindCallRequest
 [*] --> T01_S001
 T01_S001 --> T01_S002 : [(...).pulseSlot.State()==conveyor.Present]\nMigrate: s.migrateFutureMessage
-T01_S001 --> T01_S005
+T01_S001 --> T01_S004
 state "migrateFutureMessage" as T01_S003
 T01_S003 : SMVFindCallRequest
-T01_S003 --> T01_S005 : Migrate: migrateFutureMessage.1
-state "migrateFutureMessage.1" as T01_S004
-T01_S004 : SMVFindCallRequest
-T01_S004 --> [*]
-state "s.messageSender" as T01_S010 <<sdlreceive>>
-state "stepGetRequestData" as T01_S007
+T01_S003 --> T01_S004
+state "s.messageSender" as T01_S009 <<sdlreceive>>
+state "stepGetRequestData" as T01_S006
+T01_S006 : SMVFindCallRequest
+T01_S006 --[dotted]> T01_S003
+T01_S006 --> T01_S007 : [!ok]
+T01_S006 --[dashed]> T01_S006 : [smachine.NotPassed]\nWaitShared
+T01_S006 --> T01_S007 : [!foundResult]
+T01_S006 --> T01_S008
+state "stepNotFoundResponse" as T01_S007
 T01_S007 : SMVFindCallRequest
-T01_S007 --[dotted]> T01_S004
-T01_S007 --> T01_S008 : [!ok]
-T01_S007 --[dashed]> T01_S007 : [smachine.NotPassed]\nWaitShared
-T01_S007 --> T01_S008 : [!foundResult]
-T01_S007 --> T01_S009
-state "stepNotFoundResponse" as T01_S008
+T01_S007 --[dotted]> T01_S003
+T01_S007 --> T01_S008
+state "stepProcessRequest" as T01_S004
+T01_S004 : SMVFindCallRequest
+T01_S004 --[dotted]> T01_S003
+T01_S004 --> T01_S005 : [isCondPublished]
+T01_S004 --> T01_S006
+state "stepSendResponse" as T01_S008
 T01_S008 : SMVFindCallRequest
-T01_S008 --[dotted]> T01_S004
-T01_S008 --> T01_S009
-state "stepProcessRequest" as T01_S005
-T01_S005 : SMVFindCallRequest
-T01_S005 --[dotted]> T01_S004
-T01_S005 --> T01_S006 : [isCondPublished]
-T01_S005 --> T01_S007
-state "stepSendResponse" as T01_S009
-T01_S009 : SMVFindCallRequest
-T01_S009 --[dotted]> T01_S004
-T01_S009 --> T01_S010 : PrepareAsync(ctx).WithoutAutoWakeUp()
-T01_S009 --> [*]
+T01_S008 --[dotted]> T01_S003
+T01_S008 --> T01_S009 : PrepareAsync(ctx).WithoutAutoWakeUp()
+T01_S008 --> [*]
 state "stepWait" as T01_S002
 T01_S002 : SMVFindCallRequest
 T01_S002 --[dotted]> T01_S003
 T01_S002 --[dashed]> T01_S002 : Sleep
-state "stepWaitCallResult" as T01_S006
-T01_S006 : SMVFindCallRequest
-T01_S006 --[dotted]> T01_S004
-T01_S006 --[dashed]> T01_S006 : [smachine.NotPassed]\n[ctx.Acquire().IsNotPassed()]...\nWaitShared, Sleep
-T01_S006 --> T01_S007
+state "stepWaitCallResult" as T01_S005
+T01_S005 : SMVFindCallRequest
+T01_S005 --[dotted]> T01_S003
+T01_S005 --[dashed]> T01_S005 : [smachine.NotPassed]\n[ctx.Acquire().IsNotPassed()]...\nWaitShared, Sleep
+T01_S005 --> T01_S006
 state "GetInitStateFor" as T00_S001
 T00_S001 : dSMVFindCallRequest
 [*] --> T00_S001

--- a/ledger-core/virtual/integration/deduplication/find_call_request_handler_test.go
+++ b/ledger-core/virtual/integration/deduplication/find_call_request_handler_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/insolar/assured-ledger/ledger-core/vanilla/throw"
 	"github.com/insolar/assured-ledger/ledger-core/virtual/descriptor"
 	"github.com/insolar/assured-ledger/ledger-core/virtual/execute"
+	"github.com/insolar/assured-ledger/ledger-core/virtual/handlers"
 	"github.com/insolar/assured-ledger/ledger-core/virtual/integration/mock/publisher/checker"
 	"github.com/insolar/assured-ledger/ledger-core/virtual/integration/utils"
 	"github.com/insolar/assured-ledger/ledger-core/virtual/testutils"
@@ -154,6 +155,8 @@ func TestDeduplication_VFindCallRequestHandling(t *testing.T) {
 			ctx := suite.initServer(t)
 			defer suite.stopServer()
 
+			handlerEnded := suite.server.Journal.WaitStopOf(&handlers.SMVFindCallRequest{}, 1)
+
 			suite.initPulsesP1andP2(ctx)
 			suite.generateClass()
 			suite.generateCaller()
@@ -182,6 +185,7 @@ func TestDeduplication_VFindCallRequestHandling(t *testing.T) {
 			}
 
 			testutils.WaitSignalsTimed(t, 10*time.Second, suite.server.Journal.WaitAllAsyncCallsDone())
+			testutils.WaitSignalsTimed(t, 10*time.Second, handlerEnded)
 
 			suite.finish()
 		})


### PR DESCRIPTION
if message came into present pulse we should wait slot to migrate into
past. In this situation old code was setting default migration of whole
SM to "star processing" and never changed default back. This could
result in "re-start" of the operation on two rapid pulse changes.

new code:
* default migration is to "no migration", we should keep running this
handler even if pulse changes
* apply custom `jump(process)` migration only to stepWait using JumpExt,
Repeat of a step doesn't flush migration to default value

there is no sane/stable way to test this with integration test, however
decided to add check that handler SM stops after processing.

