### PR TITLE
NOISSUE: PR body in squash commit message

### DIFF
--- a/.github/bulldozer.yml
+++ b/.github/bulldozer.yml
@@ -60,7 +60,7 @@ merge:
       # "body" defines how the body of the commit message is created when
       # generating a squash commit. The options are "pull_request_body",
       # "summarize_commits", and "empty_body". The default is "empty_body".
-      body: "empty_body"
+      body: "pull_request_body"
 
       # If "body" is "pull_request_body", then the commit message will be the
       # part of the pull request body surrounded by "message_delimiter"


### PR DESCRIPTION
Despite `options.squash.body` param is set to "empty_body" bulldozer (or GitHub) sets the summary of all commits in a commit message body.
I've replaced "empty_body" with "pull_request_body" as it is the lesser of two evils.