### PR TITLE
PLAT-635: change "processing message" loglevel to INFO

### DIFF
--- a/ledger-core/virtual/handlers/handle_meta.go
+++ b/ledger-core/virtual/handlers/handle_meta.go
@@ -57,7 +57,7 @@ func (f FactoryMeta) Process(ctx context.Context, msg *statemachine.DispatcherMe
 
 	payloadType := reflect.Indirect(reflect.ValueOf(payloadObj)).Type()
 
-	logger.Debugm(struct {
+	logger.Infom(struct {
 		Message         string
 		PayloadTypeID   uint64
 		PayloadType     reflect.Type


### PR DESCRIPTION
These messages are needed during execution of VE perf tests which supposed to be executed with info loglevel.