### PR TITLE
NOISSUE: speedup deduplication tests

### DIFF
--- a/ledger-core/virtual/integration/deduplication/constructor_test.go
+++ b/ledger-core/virtual/integration/deduplication/constructor_test.go
@@ -206,9 +206,6 @@ type DeduplicationDifferentPulsesCase struct {
 func (test *DeduplicationDifferentPulsesCase) TestRun(t *testing.T) {
 	defer commontestutils.LeakTester(t)
 
-	test.TestCase.Run(t, test.run)
-
-	test.Name = test.Name + ", state already sent"
 	test.vStateSendBefore = true
 	test.TestCase.Run(t, test.run)
 }


### PR DESCRIPTION
each deduplication test has two runs:
* with already sent object data        (~ 1ms)
* with object data that sent on demand (>  1s)

so i've removed all on-demand data sent tests (that doesn't test anything)