### PR TITLE
PLAT-583: fixup tags and GA names

### DIFF
--- a/.github/workflows/long-funcs.yaml
+++ b/.github/workflows/long-funcs.yaml
@@ -8,8 +8,8 @@ env:
   CI_GOMAXPROCS: 0
   INSOLAR_LOG_LEVEL: warn
 jobs:
-  tests-on-master:
-    name: master-checks
+  long-tests-on-master:
+    name: master-long-funcs
     runs-on: ubuntu-latest
     env:
       GOPATH: /home/runner/work/assured-ledger/assured-ledger/go

--- a/ledger-core/application/api/availability_test.go
+++ b/ledger-core/application/api/availability_test.go
@@ -3,7 +3,7 @@
 // This material is licensed under the Insolar License version 1.0,
 // available at https://github.com/insolar/assured-ledger/blob/master/LICENSE.md.
 
-// +build slowtest, !longtest
+// +build slowtest,!longtest
 
 package api_test
 

--- a/ledger-core/network/integration/network_test.go
+++ b/ledger-core/network/integration/network_test.go
@@ -3,7 +3,7 @@
 // This material is licensed under the Insolar License version 1.0,
 // available at https://github.com/insolar/assured-ledger/blob/master/LICENSE.md.
 
-// +build slowtest, !longtest
+// +build slowtest,!longtest
 
 package integration
 


### PR DESCRIPTION
- tags should not contain spaces, because spaces change the condition from AND to OR
- different names for long runs so it would be easier to differ them in slack