### PR TITLE
NOISSUE: gocenter instead of goproxy

### DIFF
--- a/.github/workflows/consensus-checks.yaml
+++ b/.github/workflows/consensus-checks.yaml
@@ -8,7 +8,7 @@ env:
   CI_GOMAXPROCS: 0
   INSOLAR_LOG_LEVEL: warn
   GOPATH: /home/runner/work/
-  GOPROXY: https://proxy.golang.org,https://goproxy.io,direct
+  GOPROXY: https://proxy.golang.org,https://gocenter.io,direct
   CORE_PATH: /home/runner/work/assured-ledger/assured-ledger/ledger-core
   USE_MANIFESTS: ci
   KUBEVAL_VERSION: 0.15.0

--- a/.github/workflows/linux-checks.yaml
+++ b/.github/workflows/linux-checks.yaml
@@ -141,7 +141,7 @@ jobs:
       GOPATH: /home/runner/work
       V2_PATH: /home/runner/work/assured-ledger/assured-ledger/ledger-core
       USE_MANIFESTS: ci
-      GOPROXY: https://proxy.golang.org,https://goproxy.io,direct
+      GOPROXY: https://proxy.golang.org,https://gocenter.io,direct
       KUBEVAL_VERSION: 0.15.0
     steps:
       - name: Checkout code

--- a/.github/workflows/master-checks.yaml
+++ b/.github/workflows/master-checks.yaml
@@ -135,7 +135,7 @@ jobs:
       GOPATH: /home/runner/work/
       V2_PATH: /home/runner/work/assured-ledger/assured-ledger/ledger-core
       USE_MANIFESTS: ci
-      GOPROXY: https://proxy.golang.org,https://goproxy.io,direct
+      GOPROXY: https://proxy.golang.org,https://gocenter.io,direct
       KUBEVAL_VERSION: 0.15.0
     steps:
       - name: Checkout code

--- a/.github/workflows/ve-performance-checks.yaml
+++ b/.github/workflows/ve-performance-checks.yaml
@@ -9,7 +9,7 @@ env:
   CI_GOMAXPROCS: 0
   INSOLAR_LOG_LEVEL: warn
   GOPATH: /home/runner/work/
-  GOPROXY: https://proxy.golang.org,https://goproxy.io,direct
+  GOPROXY: https://proxy.golang.org,https://gocenter.io,direct
   CORE_PATH: /home/runner/work/assured-ledger/assured-ledger/ledger-core
   USE_MANIFESTS: aks
   ACR_HOST: usciregistry.azurecr.io


### PR DESCRIPTION
use gocenter.io instead of goproxy, because goproxy.io does not respect contract of go mod and can ffail with 410 http error

