### PR TITLE
NOISSUE: fix_ci_runs_on_wrong_commit

### DIFF
--- a/.github/workflows/linux-checks.yaml
+++ b/.github/workflows/linux-checks.yaml
@@ -18,9 +18,14 @@ jobs:
       GOPATH: /home/runner/work/assured-ledger/assured-ledger/go
     steps:
       - name: Checkout code
-        uses: actions/checkout@master
+        uses: actions/checkout@v2
         with:
           path: go/src/github.com/insolar/assured-ledger
+          # Check out pull request's HEAD commit instead of the merge commit to
+          # work-around an issue where wrong a commit is being checked out.
+          # For more details, see:
+          # https://github.com/actions/checkout/issues/299.
+          ref: ${{ github.event.pull_request.head.sha }}
       - name: Set up go ${{env.GO_VERSION}}
         uses: actions/setup-go@v2
         with:
@@ -65,9 +70,14 @@ jobs:
       GOPATH: /home/runner/work/assured-ledger/assured-ledger/go
     steps:
       - name: Checkout code
-        uses: actions/checkout@master
+        uses: actions/checkout@v2
         with:
           path: go/src/github.com/insolar/assured-ledger
+          # Check out pull request's HEAD commit instead of the merge commit to
+          # work-around an issue where wrong a commit is being checked out.
+          # For more details, see:
+          # https://github.com/actions/checkout/issues/299.
+          ref: ${{ github.event.pull_request.head.sha }}
       - name: Set up go ${{env.GO_VERSION}}
         uses: actions/setup-go@v2
         with:
@@ -145,7 +155,13 @@ jobs:
       KUBEVAL_VERSION: 0.15.0
     steps:
       - name: Checkout code
-        uses: actions/checkout@master
+        uses: actions/checkout@v2
+        with:
+          # Check out pull request's HEAD commit instead of the merge commit to
+          # work-around an issue where wrong a commit is being checked out.
+          # For more details, see:
+          # https://github.com/actions/checkout/issues/299.
+          ref: ${{ github.event.pull_request.head.sha }}
       - name: Set up go ${{env.GO_VERSION}}
         uses: actions/setup-go@v1
         with:

--- a/.github/workflows/windows-checks.yaml
+++ b/.github/workflows/windows-checks.yaml
@@ -23,9 +23,14 @@ jobs:
       BUILD_TIME: 123456
     steps:
       - name: Checkout code
-        uses: actions/checkout@master
+        uses: actions/checkout@v2
         with:
           path: go/src/github.com/insolar/assured-ledger
+          # Check out pull request's HEAD commit instead of the merge commit to
+          # work-around an issue where wrong a commit is being checked out.
+          # For more details, see:
+          # https://github.com/actions/checkout/issues/299.
+          ref: ${{ github.event.pull_request.head.sha }}
       - name: Set up go ${{env.GO_VERSION}}
         uses: actions/setup-go@v2
         with:


### PR DESCRIPTION
try to fix problem, when GHA running not on the latest commit. It causes here
https://github.com/insolar/assured-ledger/pull/568/checks?check_run_id=901992719
look at commit hashes in "checkout code" job and in left up corner
<img width="1119" alt="image" src="https://user-images.githubusercontent.com/5444090/88382164-9078de80-cdb0-11ea-95c2-29b06f44e23c.png">

discussion where i take this solution 
https://github.com/actions/checkout/issues/299

I never done this before, so i hope I do it right