### PR TITLE
NOISSUE: past eclipsed by present under constant load

### DIFF
--- a/ledger-core/conveyor/sm_pulse_slot.go
+++ b/ledger-core/conveyor/sm_pulse_slot.go
@@ -161,28 +161,23 @@ func (p *PulseSlotMachine) stepInit(ctx smachine.InitializationContext) smachine
 
 	switch p.pulseSlot.State() {
 	case Future:
-		ctx.SetDefaultMigration(p.stepMigrateFromFuture)
+		ctx.SetDefaultMigration(p.migrateFromFuture)
 		return ctx.Jump(p.stepFutureLoop)
 	case Present:
-		ctx.SetDefaultMigration(p.stepMigrateFromPresent)
-		return ctx.JumpExt(smachine.SlotStep{Transition: p.stepPresentLoop, Flags: smachine.StepPriority})
+		ctx.SetDefaultMigration(p.migrateFromPresent)
+		return ctx.Jump(p.stepPresentLoop)
 	case Past:
-		ctx.SetDefaultMigration(p.stepMigratePast)
+		ctx.SetDefaultMigration(p.migratePast)
 		return ctx.Jump(p.stepPastLoop)
 	case Antique:
-		ctx.SetDefaultMigration(p.stepMigrateAntique)
+		ctx.SetDefaultMigration(p.migrateAntique)
 		return ctx.Jump(p.stepPastLoop)
 	default:
 		panic("illegal state")
 	}
 }
 
-func (p *PulseSlotMachine) stepStop(ctx smachine.ExecutionContext) smachine.StateUpdate {
-	return ctx.Stop()
-}
-
-func (p *PulseSlotMachine) errorHandler(ctx smachine.FailureContext) {
-}
+func (p *PulseSlotMachine) errorHandler(smachine.FailureContext) {}
 
 func (p *PulseSlotMachine) onTerminate(smachine.TerminationData) {
 	p.innerMachine.RunToStop(p.innerWorker, synckit.NewNeverSignal())
@@ -207,10 +202,10 @@ func (p *PulseSlotMachine) stepFutureLoop(ctx smachine.ExecutionContext) smachin
 	return ctx.Poll().ThenRepeat()
 }
 
-func (p *PulseSlotMachine) stepMigrateFromFuture(ctx smachine.MigrationContext) smachine.StateUpdate {
-	ctx.SetDefaultMigration(p.stepMigrateFromPresent)
+func (p *PulseSlotMachine) migrateFromFuture(ctx smachine.MigrationContext) smachine.StateUpdate {
+	ctx.SetDefaultMigration(p.migrateFromPresent)
 	p._runInnerMigrate(ctx)
-	return ctx.JumpExt(smachine.SlotStep{Transition: p.stepPresentLoop, Flags: smachine.StepPriority})
+	return ctx.Jump(p.stepPresentLoop)
 }
 
 /* ------------- Present handlers --------------- */
@@ -280,11 +275,11 @@ func (p *PulseSlotMachine) cancelPulseChange(ctx smachine.BargeInContext) smachi
 		return ctx.Stay()
 	}
 
-	return ctx.JumpExt(smachine.SlotStep{Transition: p.stepPresentLoop, Flags: smachine.StepPriority})
+	return ctx.Jump(p.stepPresentLoop)
 }
 
-func (p *PulseSlotMachine) stepMigrateFromPresent(ctx smachine.MigrationContext) smachine.StateUpdate {
-	ctx.SetDefaultMigration(p.stepMigratePast)
+func (p *PulseSlotMachine) migrateFromPresent(ctx smachine.MigrationContext) smachine.StateUpdate {
+	ctx.SetDefaultMigration(p.migratePast)
 	p._runInnerMigrate(ctx)
 	return ctx.Jump(p.stepPastLoop)
 }
@@ -307,18 +302,17 @@ func (p *PulseSlotMachine) stepPastLoop(ctx smachine.ExecutionContext) smachine.
 	return ctx.WaitAny().ThenRepeat()
 }
 
-func (p *PulseSlotMachine) stepMigratePast(ctx smachine.MigrationContext) smachine.StateUpdate {
-	ctx.SkipMultipleMigrations()
+func (p *PulseSlotMachine) migratePast(ctx smachine.MigrationContext) smachine.StateUpdate {
 	p._runInnerMigrate(ctx)
 
 	if p.innerMachine.IsEmpty() {
 		ctx.UnpublishAll()
-		return ctx.Jump(p.stepStop)
+		return ctx.Stop()
 	}
 	return ctx.Stay()
 }
 
-func (p *PulseSlotMachine) stepMigrateAntique(ctx smachine.MigrationContext) smachine.StateUpdate {
+func (p *PulseSlotMachine) migrateAntique(ctx smachine.MigrationContext) smachine.StateUpdate {
 	ctx.SkipMultipleMigrations()
 	p._runInnerMigrate(ctx)
 	return ctx.Stay()

--- a/ledger-core/conveyor/sm_pulse_slot.plantuml
+++ b/ledger-core/conveyor/sm_pulse_slot.plantuml
@@ -3,41 +3,37 @@ state "GetInitStateFor" as T00_S001
 T00_S001 : PulseSlotMachine
 [*] --> T00_S001
 T00_S001 --> T00_S002
-state "stepFutureLoop" as T00_S004
+state "migrateAntique" as T00_S010
+T00_S010 : PulseSlotMachine
+state "migrateFromFuture" as T00_S004
 T00_S004 : PulseSlotMachine
-T00_S004 --[dotted]> T00_S005
-T00_S004 --[dashed]> T00_S004 : [(...).pulseManager.isPreparingPulse()]\nWaitAny, Poll
+T00_S004 --> T00_S005 : Migrate: p.migrateFromPresent
+state "migrateFromPresent" as T00_S007
+T00_S007 : PulseSlotMachine
+T00_S007 --> T00_S008 : Migrate: p.migratePast
+state "migratePast" as T00_S009
+T00_S009 : PulseSlotMachine
+T00_S009 --> [*] : [p.innerMachine.IsEmpty()]
+state "stepFutureLoop" as T00_S003
+T00_S003 : PulseSlotMachine
+T00_S003 --[dotted]> T00_S004
+T00_S003 --[dashed]> T00_S003 : [(...).pulseManager.isPreparingPulse()]\nWaitAny, Poll
 state "stepInit" as T00_S002
 T00_S002 : PulseSlotMachine
-T00_S002 --> T00_S004 : [Future]\nMigrate: p.stepMigrateFromFuture
-T00_S002 --> T00_S006 : [Present]\nMigrate: p.stepMigrateFromPresent
-T00_S002 --> T00_S009 : [Past]\nMigrate: p.stepMigratePast
-T00_S002 --> T00_S009 : [Antique]\nMigrate: p.stepMigrateAntique
-state "stepMigrateAntique" as T00_S011
-T00_S011 : PulseSlotMachine
-state "stepMigrateFromFuture" as T00_S005
-T00_S005 : PulseSlotMachine
-T00_S005 --> T00_S006 : Migrate: p.stepMigrateFromPresent
-state "stepMigrateFromPresent" as T00_S008
+T00_S002 --> T00_S003 : [Future]\nMigrate: p.migrateFromFuture
+T00_S002 --> T00_S005 : [Present]\nMigrate: p.migrateFromPresent
+T00_S002 --> T00_S008 : [Past]\nMigrate: p.migratePast
+T00_S002 --> T00_S008 : [Antique]\nMigrate: p.migrateAntique
+state "stepPastLoop" as T00_S008
 T00_S008 : PulseSlotMachine
-T00_S008 --> T00_S009 : Migrate: p.stepMigratePast
-state "stepMigratePast" as T00_S010
-T00_S010 : PulseSlotMachine
-T00_S010 --> T00_S003 : [p.innerMachine.IsEmpty()]
-state "stepPastLoop" as T00_S009
-T00_S009 : PulseSlotMachine
-T00_S009 --[dotted]> T00_S011
-T00_S009 --[dotted]> T00_S010
-T00_S009 --[dashed]> T00_S009 : [(...).pulseManager.isPreparingPulse()]\n[repeatNow]...\n[!nextPollTime.IsZero()]...\nWaitAny, Yield, WaitAnyUntil
-state "stepPreparingChange" as T00_S007
-T00_S007 : PulseSlotMachine
-T00_S007 --[dashed]> T00_S007 : [repeatNow]\n[!nextPollTime.IsZero()]...\n[(...).innerMachine.HasPriorityWork()]...\nRepeat(presentSlotCycleBoost), WaitAnyUntil, Yield
-state "stepPresentLoop" as T00_S006
+T00_S008 --[dotted]> T00_S010
+T00_S008 --[dotted]> T00_S009
+T00_S008 --[dashed]> T00_S008 : [(...).pulseManager.isPreparingPulse()]\n[repeatNow]...\n[!nextPollTime.IsZero()]...\nWaitAny, Yield, WaitAnyUntil
+state "stepPreparingChange" as T00_S006
 T00_S006 : PulseSlotMachine
-T00_S006 --[dotted]> T00_S008
-T00_S006 --[dashed]> T00_S006 : [repeatNow]\n[!nextPollTime.IsZero()]...\nRepeat(presentSlotCycleBoost), WaitAnyUntil
-state "stepStop" as T00_S003
-T00_S003 : PulseSlotMachine
-T00_S003 --[dotted]> T00_S010
-T00_S003 --> [*]
+T00_S006 --[dashed]> T00_S006 : [repeatNow]\n[!nextPollTime.IsZero()]...\n[(...).innerMachine.HasPriorityWork()]...\nRepeat(presentSlotCycleBoost), WaitAnyUntil, Yield
+state "stepPresentLoop" as T00_S005
+T00_S005 : PulseSlotMachine
+T00_S005 --[dotted]> T00_S007
+T00_S005 --[dashed]> T00_S005 : [repeatNow]\n[!nextPollTime.IsZero()]...\nRepeat(presentSlotCycleBoost), WaitAnyUntil
 @enduml


### PR DESCRIPTION
Removed priority for present pulse slot as it may prevent worker to get to past pulse slot(s)