### PR TITLE
PLAT-524: check that requests with logic error not become pending requests

### DIFF
--- a/ledger-core/virtual/integration/constructor_test.go
+++ b/ledger-core/virtual/integration/constructor_test.go
@@ -98,6 +98,8 @@ func TestVirtual_Constructor_BadClassRef(t *testing.T) {
 	server, ctx := utils.NewServer(nil, t)
 	defer server.Stop()
 
+	utils.AssertNotJumpToStep(t, server.Journal, "stepTakeLock")
+
 	executeDone := server.Journal.WaitStopOf(&execute.SMExecute{}, 2)
 
 	isolation := contract.ConstructorIsolation()
@@ -615,6 +617,8 @@ func TestVirtual_Constructor_WrongConstructorName(t *testing.T) {
 
 	server, ctx := utils.NewServer(nil, t)
 	defer server.Stop()
+
+	utils.AssertNotJumpToStep(t, server.Journal, "stepTakeLock")
 
 	executeDone := server.Journal.WaitStopOf(&execute.SMExecute{}, 1)
 

--- a/ledger-core/virtual/integration/method_test.go
+++ b/ledger-core/virtual/integration/method_test.go
@@ -99,6 +99,8 @@ func TestVirtual_BadMethod_WithExecutor(t *testing.T) {
 	defer server.Stop()
 	server.IncrementPulseAndWaitIdle(ctx)
 
+	utils.AssertNotJumpToStep(t, server.Journal, "stepTakeLock")
+
 	var (
 		class        = testwallet.GetClass()
 		objectLocal  = server.RandomLocalWithPulse()
@@ -142,7 +144,6 @@ func TestVirtual_BadMethod_WithExecutor(t *testing.T) {
 	commontestutils.WaitSignalsTimed(t, 10*time.Second, server.Journal.WaitAllAsyncCallsDone())
 
 	assert.Equal(t, 1, typedChecker.VCallResult.Count())
-
 	mc.Finish()
 }
 
@@ -202,6 +203,8 @@ func TestVirtual_Method_WithExecutor_ObjectIsNotExist(t *testing.T) {
 	server, ctx := utils.NewServer(nil, t)
 	defer server.Stop()
 	server.IncrementPulse(ctx)
+
+	utils.AssertNotJumpToStep(t, server.Journal, "stepTakeLock")
 
 	var (
 		objectLocal  = server.RandomLocalWithPulse()
@@ -1188,6 +1191,8 @@ func Test_CallMethodWithBadIsolationFlags(t *testing.T) {
 	server, ctx := utils.NewServer(nil, t)
 	defer server.Stop()
 	server.IncrementPulse(ctx)
+
+	utils.AssertNotJumpToStep(t, server.Journal, "stepTakeLock")
 
 	var (
 		objectLocal  = server.RandomLocalWithPulse()

--- a/ledger-core/virtual/integration/outgoing_test.go
+++ b/ledger-core/virtual/integration/outgoing_test.go
@@ -499,6 +499,8 @@ func TestVirtual_CallContractOutgoingReturnsError(t *testing.T) {
 	server, ctx := utils.NewUninitializedServer(nil, t)
 	defer server.Stop()
 
+	utils.AssertNotJumpToStep(t, server.Journal, "stepTakeLock")
+
 	logger := inslogger.FromContext(ctx)
 
 	executeDone := server.Journal.WaitStopOf(&execute.SMExecute{}, 2)

--- a/ledger-core/virtual/integration/utils/assert_jump.go
+++ b/ledger-core/virtual/integration/utils/assert_jump.go
@@ -1,0 +1,31 @@
+// Copyright 2020 Insolar Network Ltd.
+// All rights reserved.
+// This material is licensed under the Insolar License version 1.0,
+// available at https://github.com/insolar/assured-ledger/blob/master/LICENSE.md.
+
+package utils
+
+import (
+	"log"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/insolar/assured-ledger/ledger-core/testutils/debuglogger"
+	"github.com/insolar/assured-ledger/ledger-core/testutils/journal"
+	"github.com/insolar/assured-ledger/ledger-core/testutils/predicate"
+	"github.com/insolar/assured-ledger/ledger-core/virtual/integration/convlog"
+)
+
+func AssertNotJumpToStep(t *testing.T, j *journal.Journal, stepName string) {
+	j.Subscribe(func(event debuglogger.UpdateEvent) predicate.SubscriberState {
+		if event.Update.UpdateType == "jump" {
+			convlog.PrepareStepName(&event.Update.NextStep)
+			name := event.Update.NextStep.GetStepName()
+			log.Println(name)
+			assert.NotContains(t, name, stepName, "SM should not jump to step: "+stepName)
+		}
+
+		return predicate.RetainSubscriber
+	})
+}

--- a/ledger-core/virtual/integration/utils/assert_jump.go
+++ b/ledger-core/virtual/integration/utils/assert_jump.go
@@ -6,7 +6,6 @@
 package utils
 
 import (
-	"log"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -22,7 +21,6 @@ func AssertNotJumpToStep(t *testing.T, j *journal.Journal, stepName string) {
 		if event.Update.UpdateType == "jump" {
 			convlog.PrepareStepName(&event.Update.NextStep)
 			name := event.Update.NextStep.GetStepName()
-			log.Println(name)
 			assert.NotContains(t, name, stepName, "SM should not jump to step: "+stepName)
 		}
 

--- a/ledger-core/virtual/integration/utils/assert_jump.go
+++ b/ledger-core/virtual/integration/utils/assert_jump.go
@@ -11,10 +11,10 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/insolar/assured-ledger/ledger-core/instrumentation/convlog"
 	"github.com/insolar/assured-ledger/ledger-core/testutils/debuglogger"
 	"github.com/insolar/assured-ledger/ledger-core/testutils/journal"
 	"github.com/insolar/assured-ledger/ledger-core/testutils/predicate"
-	"github.com/insolar/assured-ledger/ledger-core/virtual/integration/convlog"
 )
 
 func AssertNotJumpToStep(t *testing.T, j *journal.Journal, stepName string) {


### PR DESCRIPTION
## What I did

- Improve tests to check that requests with logic error not become pending requests

## How I did it

- Test cases from story PLAT-391 updated with AssertNotJumpTo(stepTakeLock)
- TestRail "expected result" updated as well
- test case deleted [C5136](https://insolar.testrail.io/index.php?/cases/view/5136)


## updated test cases:

* [C4971](https://insolar.testrail.io/index.php?/cases/view/4971)
* [C4974](https://insolar.testrail.io/index.php?/cases/view/4974)
* [C4976](https://insolar.testrail.io/index.php?/cases/view/4976)
* [C4977](https://insolar.testrail.io/index.php?/cases/view/4977)
* [C4979](https://insolar.testrail.io/index.php?/cases/view/4979)
* [C5030](https://insolar.testrail.io/index.php?/cases/view/5030)

