### PR TITLE
NOISSUE: add asserts for LatestState

### DIFF
--- a/ledger-core/virtual/integration/constructor_test.go
+++ b/ledger-core/virtual/integration/constructor_test.go
@@ -940,6 +940,8 @@ func TestVirtual_CallConstructor_WithTwicePulseChange(t *testing.T) {
 		})
 		typedChecker.VDelegatedRequestFinished.Set(func(finished *payload.VDelegatedRequestFinished) bool {
 			assert.Equal(t, objectRef, finished.Callee)
+			assert.Equal(t, payload.CTConstructor, finished.CallType)
+			assert.NotNil(t, finished.LatestState)
 			assert.Equal(t, secondExpectedToken, finished.DelegationSpec)
 			assert.Equal(t, []byte("state A"), finished.LatestState.State)
 			return false

--- a/ledger-core/virtual/integration/outgoing_test.go
+++ b/ledger-core/virtual/integration/outgoing_test.go
@@ -426,6 +426,8 @@ func TestVirtual_CallConstructorOutgoing_WithTwicePulseChange(t *testing.T) {
 		typedChecker.VDelegatedRequestFinished.Set(func(finished *payload.VDelegatedRequestFinished) bool {
 			assert.Equal(t, objectRef, finished.Callee)
 			assert.Equal(t, secondExpectedToken, finished.DelegationSpec)
+			assert.Equal(t, payload.CTConstructor, finished.CallType)
+			assert.NotNil(t, finished.LatestState)
 			return false
 		})
 		typedChecker.VCallRequest.Set(func(request *payload.VCallRequest) bool {


### PR DESCRIPTION
add assert in tests VDelegaredRequestFinished if CallType == CallConstructor , then LatestState is not empty
