### PR TITLE
PLAT-731: fix TestVirtual_CallConstructorFromConstructor

### DIFF
--- a/ledger-core/virtual/integration/constructor_test.go
+++ b/ledger-core/virtual/integration/constructor_test.go
@@ -458,7 +458,7 @@ func TestVirtual_CallConstructorFromConstructor(t *testing.T) {
 		objectA   = reference.NewSelf(outgoingA.GetLocal())
 
 		classB        = server.RandomGlobalWithPulse()
-		objectBGlobal = reference.NewSelf(server.RandomLocalWithPulse())
+		objectBGlobal = server.RandomGlobalWithPulse()
 
 		outgoingCallRef = server.BuildRandomOutgoingWithPulse()
 	)
@@ -532,11 +532,11 @@ func TestVirtual_CallConstructorFromConstructor(t *testing.T) {
 				require.Equal(t, outgoingA, res.CallOutgoing)
 			default:
 				require.Equal(t, []byte("finish B.New"), res.ReturnArguments)
-				//require.Equal(t, outgoingA, res.Caller)
+				require.Equal(t, objectA, res.Caller)
 				require.Equal(t, server.GetPulse().PulseNumber, res.CallOutgoing.GetLocal().Pulse())
 			}
 			// we should resend that message only if it's CallResult from B to A
-			return true //res.Caller == outgoingA
+			return res.Caller == objectA
 		})
 	}
 


### PR DESCRIPTION
subj

```
go test -count=40000 -failfast -run=TestVirtual_CallConstructorFromConstructor ./virtual/integration/...

ok  	github.com/insolar/assured-ledger/ledger-core/virtual/integration	129.247s
ok  	github.com/insolar/assured-ledger/ledger-core/virtual/integration/benchs	0.215s [no tests to run]
ok  	github.com/insolar/assured-ledger/ledger-core/virtual/integration/deduplication	0.269s [no tests to run]
?   	github.com/insolar/assured-ledger/ledger-core/virtual/integration/mock/publisher	[no test files]
?   	github.com/insolar/assured-ledger/ledger-core/virtual/integration/mock/publisher/checker	[no test files]
?   	github.com/insolar/assured-ledger/ledger-core/virtual/integration/mock/publisher/cmd/insolar-mockgenerator-typedpublisher	[no test files]
ok  	github.com/insolar/assured-ledger/ledger-core/virtual/integration/testwallet	0.245s [no tests to run]
?   	github.com/insolar/assured-ledger/ledger-core/virtual/integration/utils	[no test files]
```


with '-race'
```
go test -race -count=4000 -failfast -run=TestVirtual_CallConstructorFromConstructor ./virtual/integration/...
ok 	github.com/insolar/assured-ledger/ledger-core/virtual/integration	65.404s
ok 	github.com/insolar/assured-ledger/ledger-core/virtual/integration/benchs	0.498s [no tests to run]
ok 	github.com/insolar/assured-ledger/ledger-core/virtual/integration/deduplication	0.736s [no tests to run]
?  	github.com/insolar/assured-ledger/ledger-core/virtual/integration/mock/publisher	[no test files]
?  	github.com/insolar/assured-ledger/ledger-core/virtual/integration/mock/publisher/checker	[no test files]
?  	github.com/insolar/assured-ledger/ledger-core/virtual/integration/mock/publisher/cmd/insolar-mockgenerator-typedpublisher	[no test files]
ok 	github.com/insolar/assured-ledger/ledger-core/virtual/integration/testwallet	0.575s [no tests to run]
?  	github.com/insolar/assured-ledger/ledger-core/virtual/integration/utils	[no test files]
```