### PR TITLE
PLAT-735: TestVirtual_DeactivateObject panic

### DIFF
--- a/ledger-core/virtual/integration/deactivate_test.go
+++ b/ledger-core/virtual/integration/deactivate_test.go
@@ -226,6 +226,7 @@ func TestVirtual_DeactivateObject(t *testing.T) {
 				executeDone = server.Journal.WaitStopOf(&execute.SMExecute{}, 1)
 				server.SendPayload(ctx, pl)
 				commonTestUtils.WaitSignalsTimed(t, 10*time.Second, executeDone)
+				commonTestUtils.WaitSignalsTimed(t, 10*time.Second, server.Journal.WaitAllAsyncCallsDone())
 			}
 
 			// Check VStateReport after pulse change


### PR DESCRIPTION
SMExecute tries to send message after test stops everything

