### PR TITLE
NOISSUE: make require to be great again in mocks

### DIFF
--- a/ledger-core/virtual/integration/mock/publisher/checker/default.go
+++ b/ledger-core/virtual/integration/mock/publisher/checker/default.go
@@ -7,8 +7,12 @@ package checker
 
 import (
 	"context"
+	"time"
 
 	"github.com/ThreeDotsLabs/watermill/message"
+
+	"github.com/insolar/assured-ledger/ledger-core/vanilla/synckit"
+	"github.com/insolar/assured-ledger/ledger-core/vanilla/throw"
 )
 
 type Sender interface {
@@ -24,26 +28,43 @@ var _ Checker = &Default{}
 type CallbackFn func(topic string, messages ...*message.Message) error
 
 type Default struct {
+	timeout   time.Duration
 	checkerFn CallbackFn
 }
 
 func (p *Default) CheckMessages(topic string, messages ...*message.Message) error {
-	return p.checkerFn(topic, messages...)
+	var (
+		done = make(synckit.ClosableSignalChannel)
+		err  error
+	)
+
+	go func() {
+		defer func() { _ = synckit.SafeClose(done) }()
+
+		err = p.checkerFn(topic, messages...)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(p.timeout):
+		err = throw.New("timeout: failed to check message")
+	}
+
+	return err
 }
 
 func NewDefault(fn CallbackFn) *Default {
 	return &Default{
+		timeout:   10 * time.Second,
 		checkerFn: fn,
 	}
 }
 
 func NewResend(ctx context.Context, sender Sender) *Default {
-	return &Default{
-		checkerFn: func(topic string, messages ...*message.Message) error {
-			for _, msg := range messages {
-				sender.SendMessage(ctx, msg)
-			}
-			return nil
-		},
-	}
+	return NewDefault(func(topic string, messages ...*message.Message) error {
+		for _, msg := range messages {
+			sender.SendMessage(ctx, msg)
+		}
+		return nil
+	})
 }

--- a/ledger-core/virtual/integration/mock/publisher/checker/typed.go
+++ b/ledger-core/virtual/integration/mock/publisher/checker/typed.go
@@ -416,6 +416,7 @@ type TypedHandlers struct {
 
 type Typed struct {
 	t             minimock.Tester
+	timeout       time.Duration
 	ctx           context.Context
 	defaultResend bool
 	resend        func(ctx context.Context, msg *message.Message)
@@ -438,6 +439,7 @@ func NewTyped(ctx context.Context, t minimock.Tester, sender Sender) *Typed {
 		t:             t,
 		ctx:           ctx,
 		defaultResend: false,
+		timeout:       10 * time.Second,
 		resend:        sender.SendMessage,
 
 		Handlers: TypedHandlers{
@@ -492,10 +494,22 @@ func (p *Typed) checkMessage(ctx context.Context, msg *message.Message) {
 
 		resend = p.defaultResend
 
-		hdlStruct.countBefore.Add(1)
+		oldCount := hdlStruct.countBefore.Add(1)
 
 		if hdlStruct.handler != nil {
-			resend = hdlStruct.handler(payload)
+			done := make(synckit.ClosableSignalChannel)
+
+			go func() {
+				defer func() { _ = synckit.SafeClose(done) }()
+
+				resend = hdlStruct.handler(payload)
+			}()
+
+			select {
+			case <-done:
+			case <-time.After(p.timeout):
+				p.t.Error("timeout: failed to check message VCallRequest (position: %s)", oldCount)
+			}
 		} else if !p.defaultResend && !hdlStruct.touched {
 			p.t.Fatalf("unexpected %T payload", payload)
 			return
@@ -508,10 +522,22 @@ func (p *Typed) checkMessage(ctx context.Context, msg *message.Message) {
 
 		resend = p.defaultResend
 
-		hdlStruct.countBefore.Add(1)
+		oldCount := hdlStruct.countBefore.Add(1)
 
 		if hdlStruct.handler != nil {
-			resend = hdlStruct.handler(payload)
+			done := make(synckit.ClosableSignalChannel)
+
+			go func() {
+				defer func() { _ = synckit.SafeClose(done) }()
+
+				resend = hdlStruct.handler(payload)
+			}()
+
+			select {
+			case <-done:
+			case <-time.After(p.timeout):
+				p.t.Error("timeout: failed to check message VCallResult (position: %s)", oldCount)
+			}
 		} else if !p.defaultResend && !hdlStruct.touched {
 			p.t.Fatalf("unexpected %T payload", payload)
 			return
@@ -524,10 +550,22 @@ func (p *Typed) checkMessage(ctx context.Context, msg *message.Message) {
 
 		resend = p.defaultResend
 
-		hdlStruct.countBefore.Add(1)
+		oldCount := hdlStruct.countBefore.Add(1)
 
 		if hdlStruct.handler != nil {
-			resend = hdlStruct.handler(payload)
+			done := make(synckit.ClosableSignalChannel)
+
+			go func() {
+				defer func() { _ = synckit.SafeClose(done) }()
+
+				resend = hdlStruct.handler(payload)
+			}()
+
+			select {
+			case <-done:
+			case <-time.After(p.timeout):
+				p.t.Error("timeout: failed to check message VDelegatedCallRequest (position: %s)", oldCount)
+			}
 		} else if !p.defaultResend && !hdlStruct.touched {
 			p.t.Fatalf("unexpected %T payload", payload)
 			return
@@ -540,10 +578,22 @@ func (p *Typed) checkMessage(ctx context.Context, msg *message.Message) {
 
 		resend = p.defaultResend
 
-		hdlStruct.countBefore.Add(1)
+		oldCount := hdlStruct.countBefore.Add(1)
 
 		if hdlStruct.handler != nil {
-			resend = hdlStruct.handler(payload)
+			done := make(synckit.ClosableSignalChannel)
+
+			go func() {
+				defer func() { _ = synckit.SafeClose(done) }()
+
+				resend = hdlStruct.handler(payload)
+			}()
+
+			select {
+			case <-done:
+			case <-time.After(p.timeout):
+				p.t.Error("timeout: failed to check message VDelegatedCallResponse (position: %s)", oldCount)
+			}
 		} else if !p.defaultResend && !hdlStruct.touched {
 			p.t.Fatalf("unexpected %T payload", payload)
 			return
@@ -556,10 +606,22 @@ func (p *Typed) checkMessage(ctx context.Context, msg *message.Message) {
 
 		resend = p.defaultResend
 
-		hdlStruct.countBefore.Add(1)
+		oldCount := hdlStruct.countBefore.Add(1)
 
 		if hdlStruct.handler != nil {
-			resend = hdlStruct.handler(payload)
+			done := make(synckit.ClosableSignalChannel)
+
+			go func() {
+				defer func() { _ = synckit.SafeClose(done) }()
+
+				resend = hdlStruct.handler(payload)
+			}()
+
+			select {
+			case <-done:
+			case <-time.After(p.timeout):
+				p.t.Error("timeout: failed to check message VDelegatedRequestFinished (position: %s)", oldCount)
+			}
 		} else if !p.defaultResend && !hdlStruct.touched {
 			p.t.Fatalf("unexpected %T payload", payload)
 			return
@@ -572,10 +634,22 @@ func (p *Typed) checkMessage(ctx context.Context, msg *message.Message) {
 
 		resend = p.defaultResend
 
-		hdlStruct.countBefore.Add(1)
+		oldCount := hdlStruct.countBefore.Add(1)
 
 		if hdlStruct.handler != nil {
-			resend = hdlStruct.handler(payload)
+			done := make(synckit.ClosableSignalChannel)
+
+			go func() {
+				defer func() { _ = synckit.SafeClose(done) }()
+
+				resend = hdlStruct.handler(payload)
+			}()
+
+			select {
+			case <-done:
+			case <-time.After(p.timeout):
+				p.t.Error("timeout: failed to check message VFindCallRequest (position: %s)", oldCount)
+			}
 		} else if !p.defaultResend && !hdlStruct.touched {
 			p.t.Fatalf("unexpected %T payload", payload)
 			return
@@ -588,10 +662,22 @@ func (p *Typed) checkMessage(ctx context.Context, msg *message.Message) {
 
 		resend = p.defaultResend
 
-		hdlStruct.countBefore.Add(1)
+		oldCount := hdlStruct.countBefore.Add(1)
 
 		if hdlStruct.handler != nil {
-			resend = hdlStruct.handler(payload)
+			done := make(synckit.ClosableSignalChannel)
+
+			go func() {
+				defer func() { _ = synckit.SafeClose(done) }()
+
+				resend = hdlStruct.handler(payload)
+			}()
+
+			select {
+			case <-done:
+			case <-time.After(p.timeout):
+				p.t.Error("timeout: failed to check message VFindCallResponse (position: %s)", oldCount)
+			}
 		} else if !p.defaultResend && !hdlStruct.touched {
 			p.t.Fatalf("unexpected %T payload", payload)
 			return
@@ -604,10 +690,22 @@ func (p *Typed) checkMessage(ctx context.Context, msg *message.Message) {
 
 		resend = p.defaultResend
 
-		hdlStruct.countBefore.Add(1)
+		oldCount := hdlStruct.countBefore.Add(1)
 
 		if hdlStruct.handler != nil {
-			resend = hdlStruct.handler(payload)
+			done := make(synckit.ClosableSignalChannel)
+
+			go func() {
+				defer func() { _ = synckit.SafeClose(done) }()
+
+				resend = hdlStruct.handler(payload)
+			}()
+
+			select {
+			case <-done:
+			case <-time.After(p.timeout):
+				p.t.Error("timeout: failed to check message VStateReport (position: %s)", oldCount)
+			}
 		} else if !p.defaultResend && !hdlStruct.touched {
 			p.t.Fatalf("unexpected %T payload", payload)
 			return
@@ -620,10 +718,22 @@ func (p *Typed) checkMessage(ctx context.Context, msg *message.Message) {
 
 		resend = p.defaultResend
 
-		hdlStruct.countBefore.Add(1)
+		oldCount := hdlStruct.countBefore.Add(1)
 
 		if hdlStruct.handler != nil {
-			resend = hdlStruct.handler(payload)
+			done := make(synckit.ClosableSignalChannel)
+
+			go func() {
+				defer func() { _ = synckit.SafeClose(done) }()
+
+				resend = hdlStruct.handler(payload)
+			}()
+
+			select {
+			case <-done:
+			case <-time.After(p.timeout):
+				p.t.Error("timeout: failed to check message VStateRequest (position: %s)", oldCount)
+			}
 		} else if !p.defaultResend && !hdlStruct.touched {
 			p.t.Fatalf("unexpected %T payload", payload)
 			return


### PR DESCRIPTION
require uses FailNow that uses runtime.GoExit() to stop goroutine
use separate goroutine (with timeout) to handle that case correctly

