### PR TITLE
PLAT-762: on very rare ocasion StateReport goes out faster than result

### DIFF
--- a/ledger-core/virtual/integration/constructor_test.go
+++ b/ledger-core/virtual/integration/constructor_test.go
@@ -362,6 +362,7 @@ func TestVirtual_Constructor_PrevPulseStateWithMissingStatus(t *testing.T) {
 
 	server.SendPayload(ctx, pl)
 	commontestutils.WaitSignalsTimed(t, 10*time.Second, executeDone)
+	commontestutils.WaitSignalsTimed(t, 10*time.Second, server.Journal.WaitAllAsyncCallsDone())
 
 	server.IncrementPulseAndWaitIdle(ctx)
 	commontestutils.WaitSignalsTimed(t, 10*time.Second, typedChecker.VStateReport.Wait(ctx, 1))


### PR DESCRIPTION
Async adapter call to send VCallResult takes more than to switch pulse
and send out reports, check of .VCallResult.Count() was failing

