### PR TITLE
PLAT-767: WaitStopOf should be called before SM is created

### DIFF
--- a/ledger-core/virtual/integration/constructor_test.go
+++ b/ledger-core/virtual/integration/constructor_test.go
@@ -830,6 +830,7 @@ func TestVirtual_CallConstructor_WithTwicePulseChange(t *testing.T) {
 	pl := utils.GenerateVCallRequestConstructor(server)
 	pl.Callee = classA
 	pl.CallOutgoing = outgoing
+	execDone := server.Journal.WaitStopOf(&execute.SMExecute{}, 1)
 	server.SendPayload(ctx, pl)
 
 	// wait for results
@@ -850,7 +851,7 @@ func TestVirtual_CallConstructor_WithTwicePulseChange(t *testing.T) {
 
 		synchronizeExecution.Done()
 		// wait for SMExecutcute finish
-		commontestutils.WaitSignalsTimed(t, 10*time.Second, server.Journal.WaitStopOf(&execute.SMExecute{}, 1))
+		commontestutils.WaitSignalsTimed(t, 10*time.Second, execDone)
 		commontestutils.WaitSignalsTimed(t, 10*time.Second, server.Journal.WaitAllAsyncCallsDone())
 	}
 

--- a/ledger-core/virtual/integration/deactivate_test.go
+++ b/ledger-core/virtual/integration/deactivate_test.go
@@ -439,8 +439,9 @@ func TestVirtual_CallDeactivate_Intolerable(t *testing.T) {
 				pl.Callee = objectGlobal
 				pl.CallSiteMethod = "Destroy"
 
+				execDone := server.Journal.WaitStopOf(&execute.SMExecute{}, 1)
 				server.SendPayload(ctx, pl)
-				commonTestUtils.WaitSignalsTimed(t, 10*time.Second, server.Journal.WaitStopOf(&execute.SMExecute{}, 1))
+				commonTestUtils.WaitSignalsTimed(t, 10*time.Second, execDone)
 			}
 
 			commonTestUtils.WaitSignalsTimed(t, 10*time.Second, server.Journal.WaitAllAsyncCallsDone())

--- a/ledger-core/virtual/integration/method_test.go
+++ b/ledger-core/virtual/integration/method_test.go
@@ -1053,8 +1053,9 @@ func TestVirtual_FutureMessageAddedToSlot(t *testing.T) {
 	jetCoordinatorMock.MeMock.Return(server.GlobalCaller())
 
 	// switch pulse and start processing request from future slot
+	execDone := server.Journal.WaitStopOf(&execute.SMExecute{}, 1)
 	server.IncrementPulseAndWaitIdle(ctx)
-	commontestutils.WaitSignalsTimed(t, 10*time.Second, server.Journal.WaitStopOf(&execute.SMExecute{}, 1))
+	commontestutils.WaitSignalsTimed(t, 10*time.Second, execDone)
 	commontestutils.WaitSignalsTimed(t, 10*time.Second, server.Journal.WaitAllAsyncCallsDone())
 
 	mc.Finish()


### PR DESCRIPTION
in all these tests some times SM can finish before we call WaitStopOf
and test finishes with the timeout

