### PR TITLE
HOTFIX: disable annoying codecov annotations

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -9,3 +9,5 @@ coverage:
     project:
       default:
         threshold: 1%
+github_checks:
+  annotations: false


### PR DESCRIPTION
Because status checks are just enough