### PR TITLE
NOISSUE: Access control flag for shared data

### DIFF
--- a/ledger-core/conveyor/smachine/api_context.go
+++ b/ledger-core/conveyor/smachine/api_context.go
@@ -240,6 +240,11 @@ const (
 	// But keeping such SharedDataLink will retain the data in memory even when invalidated.
 	// ShareDataDirect is overridden by ShareDataUnbound.
 	ShareDataDirect
+
+	// ShareDataWithOtherSlotMachines allows access to it form SM's under different SlotMachine(s).
+	// By default, access only is allowed to SM's of owner's SlotMachine.
+	// This flag is ignored when either ShareDataUnbound or ShareDataDirect is set.
+	ShareDataWithOtherSlotMachines
 )
 
 type SubroutineCleanupMode uint8

--- a/ledger-core/conveyor/smachine/slot_machine.go
+++ b/ledger-core/conveyor/smachine/slot_machine.go
@@ -944,6 +944,8 @@ func (m *SlotMachine) useSlotAsShared(link SharedDataLink, accessFn SharedDataFu
 		return SharedSlotAbsent
 	case tm == nil:
 		return SharedSlotAbsent
+	case tm != m && !link.isSharedForOthers():
+		return SharedSlotAbsent
 	case isBusy:
 		if m == tm {
 			return SharedSlotLocalBusy


### PR DESCRIPTION
* added ShareDataWithOtherSlotMachines to explicitly enable access to shared data by SM's from other SlotMachines
* GoDoc improvements

