### PR TITLE
NOISSUE: fix for long running tests

### DIFF
--- a/ledger-core/testutils/pulsegenerator.go
+++ b/ledger-core/testutils/pulsegenerator.go
@@ -50,6 +50,10 @@ func (g *PulseGenerator) GetPrevBeat() beat.Beat {
 	return g.prev
 }
 
+func (g *PulseGenerator) GetDelta() uint16 {
+	return g.delta
+}
+
 func generateEntropy() (entropy longbits.Bits256) {
 	if _, err := rand.Read(entropy[:]); err != nil {
 		panic(err)
@@ -63,7 +67,7 @@ func (g *PulseGenerator) Generate() pulse.Data {
 	} else {
 		g.prev = g.last
 		g.last = beat.Beat{
-			Data: g.last.CreateNextPulsarPulse(g.delta, generateEntropy),
+			Data:   g.last.CreateNextPulsarPulse(g.delta, generateEntropy),
 			Online: g.prev.Online,
 		}
 	}

--- a/ledger-core/virtual/integration/object_test.go
+++ b/ledger-core/virtual/integration/object_test.go
@@ -7,7 +7,6 @@ package integration
 
 import (
 	"testing"
-	"time"
 
 	"github.com/gojuno/minimock/v3"
 	"github.com/stretchr/testify/assert"
@@ -49,12 +48,14 @@ func TestInitViaCTMethod(t *testing.T) {
 		server.SendPayload(ctx, pl)
 	}
 
+	waitTime := server.GetPulseTime()
+
 	// potentially failing test, if execution would sleep for some time before that check
-	if server.PublisherMock.WaitCount(1, 500*time.Millisecond) {
+	if server.PublisherMock.WaitCount(1, waitTime/20) {
 		require.Failf(t, "", "SM Object needs to wait until sm.waitGetStateUntil (potentialy failing)")
 	}
 
-	if !server.PublisherMock.WaitCount(1, 1*time.Second) {
+	if !server.PublisherMock.WaitCount(1, waitTime/5) {
 		require.Failf(t, "", "timeout")
 	}
 }


### PR DESCRIPTION
* pulse time is now 1 second instead of 10 second for VE integration tests (that means delay for waiting of VStateReport 0.1ms instead of 1s)
* fixed one test that relies on 1s delay

