### PR TITLE
PLAT-830: disable time related checks for now

### DIFF
--- a/ledger-core/log/global/struct_log_test.go
+++ b/ledger-core/log/global/struct_log_test.go
@@ -12,7 +12,6 @@ import (
 	"reflect"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/insolar/assured-ledger/ledger-core/log/logcommon"
 	"github.com/insolar/assured-ledger/ledger-core/log/logoutput"
@@ -110,11 +109,12 @@ func TestLogFieldsMarshaler(t *testing.T) {
 		require.Equal(t, "warn", c["level"], "right message")
 		require.Equal(t, logstring, c["message"], "right message")
 		require.Contains(t, c["caller"], fileLine, "right caller line")
-		ltime, err := time.Parse(time.RFC3339Nano, c["time"].(string))
-		require.NoError(t, err, "parseable time")
-		ldur := time.Since(ltime)
-		assert.True(t, ldur >= 0, "worktime is not less than zero")
-		assert.True(t, ldur < time.Second, "worktime is less than a second")
+		// TODO: PLAT-830
+		// ltime, err := time.Parse(time.RFC3339Nano, c["time"].(string))
+		// require.NoError(t, err, "parseable time")
+		// ldur := time.Since(ltime)
+		// assert.True(t, ldur >= 0, "worktime is not less than zero")
+		// assert.True(t, ldur < time.Second, "worktime is less than a second")
 		assert.Equal(t, 200.200, c["testfield"], "customfield")
 		assert.NotNil(t, c["writeDuration"], "duration exists")
 	}


### PR DESCRIPTION
Test is time related and is failing with race.
Probably  should be moved to benchmark