### PR TITLE
NOISSUE: set journal predicate before payload is sent

### DIFF
--- a/ledger-core/virtual/integration/staterequest_test.go
+++ b/ledger-core/virtual/integration/staterequest_test.go
@@ -193,8 +193,8 @@ func TestVirtual_VStateRequest_WhenObjectIsDeactivated(t *testing.T) {
 
 			// Send VStateReport
 			{
-				server.SendPayload(ctx, vStateReport)
 				reportSend := server.Journal.WaitStopOf(&handlers.SMVStateReport{}, 1)
+				server.SendPayload(ctx, vStateReport)
 				commontestutils.WaitSignalsTimed(t, 10*time.Second, reportSend)
 			}
 


### PR DESCRIPTION
Predicate for Journal wait should be created before payload is sent. If timing is wrong event could happen before wait