### PR TITLE
NOISSUE: migration is called if pulse changes after replace, but before init

### DIFF
--- a/ledger-core/virtual/execute/execute.go
+++ b/ledger-core/virtual/execute/execute.go
@@ -145,6 +145,11 @@ func (s *SMExecute) migrationDefault(ctx smachine.MigrationContext) smachine.Sta
 }
 
 func (s *SMExecute) Init(ctx smachine.InitializationContext) smachine.StateUpdate {
+	if s.pulseSlot.State() != conveyor.Present {
+		ctx.Log().Trace("not processing SMExecute since we are not in present pulse")
+		return ctx.Stop()
+	}
+
 	s.prepareExecution(ctx.GetContext())
 
 	ctx.SetDefaultMigration(s.migrationDefault)


### PR DESCRIPTION
it's possible that it's a bug implementation of ctx.Replace