### PR TITLE
NOISSUE: replace should inherit migration status from origin

### DIFF
--- a/ledger-core/virtual/execute/execute.go
+++ b/ledger-core/virtual/execute/execute.go
@@ -153,6 +153,10 @@ func (s *SMExecute) Init(ctx smachine.InitializationContext) smachine.StateUpdat
 }
 
 func (s *SMExecute) stepCheckRequest(ctx smachine.ExecutionContext) smachine.StateUpdate {
+	if s.pulseSlot.State() != conveyor.Present {
+		panic(throw.IllegalState())
+	}
+
 	switch s.Payload.CallType {
 	case rms.CallTypeConstructor:
 	case rms.CallTypeMethod:


### PR DESCRIPTION
it should be impossible