### PR TITLE
NOISSUE: fix pointer conversion in rms

### DIFF
--- a/ledger-core/rms/rmsbox/any_lazy.go
+++ b/ledger-core/rms/rmsbox/any_lazy.go
@@ -238,6 +238,10 @@ func (p LazyValue) UnmarshalAsType(vType reflect.Type, skipFn rmsreg.UnknownCall
 		return nil, nil
 	}
 
+	if vType.Kind() == reflect.Ptr {
+		vType = vType.Elem()
+	}
+
 	v := reflect.New(vType).Interface()
 	if err := p.unmarshalAsAny(v, skipFn); err != nil {
 		return nil, err
@@ -261,7 +265,7 @@ func (p LazyValue) UnmarshalCustom(registry *rmsreg.TypeRegistry, skipFn rmsreg.
 	switch {
 	case err != nil:
 	case !t.Implements(typeGoGoSerializable):
-		err = throw.E("incompatible with GoGoSerializable", struct { Type reflect.Type }{ t })
+		err = throw.E("incompatible with GoGoSerializable", struct{ Type reflect.Type }{t})
 
 	case t.Implements(typeBasicMessage):
 		payloads := RecordPayloads{}
@@ -313,10 +317,10 @@ func (p LazyValue) unmarshalAsAny(v interface{}, skipFn rmsreg.UnknownCallbackFu
 
 	// try to get polymorph id
 	if id, _, err2 := protokit.DecodePolymorphFromBytes(p.value, false); err2 == nil {
-		err = throw.WithDetails(err, struct{ ID uint64 }{id })
+		err = throw.WithDetails(err, struct{ ID uint64 }{id})
 	}
 
-	return throw.WithDetails(err, struct{ Type reflect.Type }{ reflect.TypeOf(v) })
+	return throw.WithDetails(err, struct{ Type reflect.Type }{reflect.TypeOf(v)})
 }
 
 func (p LazyValue) ProtoSize() int {
@@ -331,7 +335,7 @@ func (p LazyValue) MarshalToSizedBuffer(b []byte) (int, error) {
 	if len(b) < len(p.value) {
 		return 0, io.ErrShortBuffer
 	}
-	return copy(b[len(b) - len(p.value):], p.value), nil
+	return copy(b[len(b)-len(p.value):], p.value), nil
 }
 
 func (p LazyValue) MarshalText() ([]byte, error) {

--- a/ledger-core/rms/rmsreg/registry.go
+++ b/ledger-core/rms/rmsreg/registry.go
@@ -30,9 +30,9 @@ func SetRegistry(r *TypeRegistry) {
 var unmarshalerType = reflect.TypeOf((*unmarshaler)(nil)).Elem()
 
 type TypeRegistry struct {
-	mutex     sync.RWMutex
-	commons   map[uint64]reflect.Type
-	specials  map[string]map[uint64]reflect.Type
+	mutex    sync.RWMutex
+	commons  map[uint64]reflect.Type
+	specials map[string]map[uint64]reflect.Type
 
 	digester  cryptkit.DataDigester
 	digesters map[uint64]cryptkit.DataDigester
@@ -204,6 +204,10 @@ func UnmarshalAs(b []byte, obj interface{}, skipFn UnknownCallbackFunc) error {
 }
 
 func UnmarshalAsType(b []byte, vType reflect.Type, skipFn UnknownCallbackFunc) (interface{}, error) {
+	if vType.Kind() == reflect.Ptr {
+		vType = vType.Elem()
+	}
+
 	obj := reflect.New(vType).Interface()
 	if err := UnmarshalAs(b, obj, skipFn); err != nil {
 		return nil, err


### PR DESCRIPTION
* `reflect.New(vType).Interface()` returns pointer to `vType` instance
* `vType` is already a "pointer"
* result object became, for example, `**rms.ROutboundRequest`
* it doesn't implement `rmsreg.unmarshaler` -> `panic`

