### PR TITLE
NOISSUE: add dry run for SubSMRegister

### DIFF
--- a/ledger-core/virtual/lmn/register.go
+++ b/ledger-core/virtual/lmn/register.go
@@ -106,6 +106,7 @@ type SubSMRegister struct {
 	IncomingResult    *execution.Update
 	Interference      isolation.InterferenceFlag
 	ObjectSharedState object.SharedStateAccessor
+	DryRun            bool
 
 	Object          reference.Global
 	LastFilamentRef reference.Global
@@ -199,7 +200,16 @@ func (s *SubSMRegister) bargeInHandler(param interface{}) smachine.BargeInCallba
 }
 
 func (s *SubSMRegister) registerMessage(ctx smachine.ExecutionContext, msg *rms.LRegisterRequest) error {
-	waitFlag := msg.Flags
+	var (
+		waitFlag   = msg.Flags
+		bargeInKey = NewResultAwaitKey(msg.AnticipatedRef, waitFlag)
+	)
+
+	if s.DryRun {
+		s.messages.AppendMessage(msg, bargeInKey)
+
+		return nil
+	}
 
 	switch msg.Flags {
 	case rms.RegistrationFlags_FastSafe:
@@ -219,17 +229,17 @@ func (s *SubSMRegister) registerMessage(ctx smachine.ExecutionContext, msg *rms.
 		fallthrough
 	case rms.RegistrationFlags_Fast, rms.RegistrationFlags_Safe:
 		var (
-			bargeInKey = NewResultAwaitKey(msg.AnticipatedRef, waitFlag)
-			bargeIn    = ctx.NewBargeInWithParam(s.bargeInHandler)
+			bargeIn = ctx.NewBargeInWithParam(s.bargeInHandler)
 		)
 
 		if !ctx.PublishGlobalAliasAndBargeIn(bargeInKey, bargeIn) {
 			return throw.E("failed to publish bargeIn callback")
 		}
-		s.messages.AppendMessage(msg, bargeInKey)
 	default:
 		panic(throw.IllegalValue())
 	}
+
+	s.messages.AppendMessage(msg, bargeInKey)
 
 	return nil
 }
@@ -661,6 +671,10 @@ func (s *SubSMRegister) stepSaveSafeCounter(ctx smachine.ExecutionContext) smach
 		panic(throw.IllegalState())
 	}
 
+	if s.DryRun {
+		return ctx.Jump(s.stepDone)
+	}
+
 	stateUpdate := shared.CounterIncrement(ctx, s.SafeResponseCounter, s.requiredSafe)
 	if !stateUpdate.IsEmpty() {
 		return stateUpdate
@@ -681,7 +695,7 @@ func (s *SubSMRegister) stepSendMessage(ctx smachine.ExecutionContext) smachine.
 	)
 
 	if msg == nil {
-		return ctx.Stop()
+		return ctx.Jump(s.stepDone)
 	}
 
 	s.messageSender.PrepareAsync(ctx, func(goCtx context.Context, svc messagesender.Service) smachine.AsyncResultFunc {
@@ -704,4 +718,16 @@ func (s *SubSMRegister) stepWaitResponse(ctx smachine.ExecutionContext) smachine
 	}
 
 	return ctx.Jump(s.stepSendMessage)
+}
+
+func (s *SubSMRegister) stepDone(ctx smachine.ExecutionContext) smachine.StateUpdate {
+	return ctx.Stop()
+}
+
+func (s *SubSMRegister) GetMessages() []rmsreg.GoGoSerializable {
+	messages := make([]rmsreg.GoGoSerializable, 0, len(s.messages.messages))
+	for _, msg := range s.messages.messages {
+		messages = append(messages, msg.payload)
+	}
+	return messages
 }

--- a/ledger-core/virtual/lmn/register.plantuml
+++ b/ledger-core/virtual/lmn/register.plantuml
@@ -28,6 +28,14 @@ T01_S006 : SubSMRegister
 T01_S006 --[dotted]> T01_S006
 T01_S006 --> [*]
 state "s.messageSender" as T01_S014 <<sdlreceive>>
+state "stepDone" as T01_S016
+T01_S016 : SubSMRegister
+T01_S016 --[dotted]> T01_S002
+T01_S016 --[dotted]> T01_S003
+T01_S016 --[dotted]> T01_S004
+T01_S016 --[dotted]> T01_S005
+T01_S016 --[dotted]> T01_S006
+T01_S016 --> [*]
 state "stepRegisterIncoming" as T01_S008
 T01_S008 : SubSMRegister
 T01_S008 --[dotted]> T01_S003
@@ -65,6 +73,7 @@ T01_S012 --[dotted]> T01_S003
 T01_S012 --[dotted]> T01_S004
 T01_S012 --[dotted]> T01_S005
 T01_S012 --[dotted]> T01_S006
+T01_S012 --> T01_S016 : [s.DryRun]
 T01_S012 --> T01_S012 : [!stateUpdate.IsEmpty()]
 T01_S012 --> T01_S013
 state "stepSendMessage" as T01_S013
@@ -74,7 +83,7 @@ T01_S013 --[dotted]> T01_S003
 T01_S013 --[dotted]> T01_S004
 T01_S013 --[dotted]> T01_S005
 T01_S013 --[dotted]> T01_S006
-T01_S013 --> [*] : [msg==nil]
+T01_S013 --> T01_S016 : [msg==nil]
 T01_S013 --> T01_S014 : PrepareAsync(ctx).WithoutAutoWakeUp()
 T01_S013 --> T01_S015
 state "stepWaitResponse" as T01_S015


### PR DESCRIPTION
DryRun flag gives ability to execute SubSMRegister without sending messages or modifying external state