### PR TITLE
NOISSUE: rmsbox.Reference support for explicit empty value

### DIFF
--- a/ledger-core/rms/rmsbox/binary.go
+++ b/ledger-core/rms/rmsbox/binary.go
@@ -24,11 +24,11 @@ func (p *Binary) ProtoSize() int {
 }
 
 func (p *Binary) MarshalTo(b []byte) (int, error) {
-	return protokit.BinaryMarshalTo(b, p.rawBinary.marshalTo)
+	return protokit.BinaryMarshalTo(b, false, p.rawBinary.marshalTo)
 }
 
 func (p *Binary) MarshalToSizedBuffer(b []byte) (int, error) {
-	return protokit.BinaryMarshalToSizedBuffer(b, p.rawBinary.marshalToSizedBuffer)
+	return protokit.BinaryMarshalToSizedBuffer(b, false, p.rawBinary.marshalToSizedBuffer)
 }
 
 func (p *Binary) Unmarshal(b []byte) error {

--- a/ledger-core/rms/rmsbox/record_body.go
+++ b/ledger-core/rms/rmsbox/record_body.go
@@ -205,7 +205,7 @@ func (p *RecordBody) _rawPreparedSize() int {
 
 func (p *RecordBody) MarshalTo(b []byte) (int, error) {
 	p.ensure()
-	return protokit.BinaryMarshalTo(b, p._marshal)
+	return protokit.BinaryMarshalTo(b, false, p._marshal)
 }
 
 func (p *RecordBody) _marshal(b []byte) (int, error) {
@@ -226,7 +226,7 @@ func (p *RecordBody) _marshal(b []byte) (int, error) {
 
 func (p *RecordBody) MarshalToSizedBuffer(b []byte) (int, error) {
 	p.ensure()
-	return protokit.BinaryMarshalToSizedBuffer(b, func(b []byte) (int, error) {
+	return protokit.BinaryMarshalToSizedBuffer(b, false, func(b []byte) (int, error) {
 		n := p._rawPreparedSize()
 		return p._marshal(b[len(b)-n:])
 	})

--- a/ledger-core/rms/rmsbox/record_payloads.go
+++ b/ledger-core/rms/rmsbox/record_payloads.go
@@ -74,7 +74,7 @@ func (p *RecordPayloads) MarshalTo(b []byte) (int, error) {
 		if rawBytes {
 			n, err = pl.marshalTo(b[pos : pos+sz])
 		} else {
-			n, err = protokit.BinaryMarshalTo(b[pos:pos+sz], pl.marshalTo)
+			n, err = protokit.BinaryMarshalTo(b[pos:pos+sz], false, pl.marshalTo)
 		}
 		switch {
 		case err != nil:

--- a/ledger-core/rms/rmsbox/reference_test.go
+++ b/ledger-core/rms/rmsbox/reference_test.go
@@ -1,0 +1,65 @@
+// Copyright 2020 Insolar Network Ltd.
+// All rights reserved.
+// This material is licensed under the Insolar License version 1.0,
+// available at https://github.com/insolar/assured-ledger/blob/master/LICENSE.md.
+
+package rmsbox
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/insolar/assured-ledger/ledger-core/reference"
+)
+
+func TestReferenceZeroOrEmpty(t *testing.T) {
+	b := make([]byte, 64)
+
+	ref := Reference{}
+	require.True(t, ref.IsZero())
+	require.True(t, ref.IsEmpty())
+	n, err := ref.MarshalTo(b)
+	require.NoError(t, err)
+	require.Zero(t, n)
+
+	ref.Set(reference.Global{})
+	require.True(t, ref.IsZero())
+	require.True(t, ref.IsEmpty())
+	n, err = ref.MarshalTo(b)
+	require.NoError(t, err)
+	require.Zero(t, n)
+
+	ref.Set(nil)
+	require.True(t, ref.IsZero())
+	require.True(t, ref.IsEmpty())
+	n, err = ref.MarshalTo(b)
+	require.NoError(t, err)
+	require.Zero(t, n)
+
+	ref.SetExact(reference.Global{})
+	require.False(t, ref.IsZero())
+	require.True(t, ref.IsEmpty())
+	n, err = ref.MarshalTo(b)
+	require.NoError(t, err)
+	require.Equal(t, 1, n)
+
+	ref2 := Reference{}
+	err = ref2.Unmarshal(b[:n])
+	require.NoError(t, err)
+	require.False(t, ref.IsZero())
+	require.True(t, ref.IsEmpty())
+
+	ref.SetExact(nil)
+	require.True(t, ref.IsZero())
+	require.True(t, ref.IsEmpty())
+	n, err = ref.MarshalTo(b)
+	require.NoError(t, err)
+	require.Zero(t, n)
+
+	ref2 = Reference{}
+	err = ref2.Unmarshal(b[:0])
+	require.NoError(t, err)
+	require.True(t, ref.IsZero())
+	require.True(t, ref.IsEmpty())
+}

--- a/ledger-core/vanilla/protokit/binary.go
+++ b/ledger-core/vanilla/protokit/binary.go
@@ -18,7 +18,7 @@ func BinaryProtoSize(n int) int {
 	return n
 }
 
-func BinaryMarshalTo(b []byte, marshalTo func([]byte) (int, error)) (int, error) {
+func BinaryMarshalTo(b []byte, allowEmpty bool, marshalTo func([]byte) (int, error)) (int, error) {
 	if len(b) == 0 {
 		return marshalTo(nil)
 	}
@@ -26,18 +26,18 @@ func BinaryMarshalTo(b []byte, marshalTo func([]byte) (int, error)) (int, error)
 	switch n, err := marshalTo(b[1:]); {
 	case err != nil:
 		return 0, err
-	case n == 0:
+	case !allowEmpty && n == 0:
 		return 0, nil
 	default:
 		return n + 1, nil
 	}
 }
 
-func BinaryMarshalToSizedBuffer(b []byte, marshalToSizedBuffer func([]byte) (int, error)) (int, error) {
+func BinaryMarshalToSizedBuffer(b []byte, allowEmpty bool, marshalToSizedBuffer func([]byte) (int, error)) (int, error) {
 	switch n, err := marshalToSizedBuffer(b[1:]); {
 	case err != nil:
 		return 0, err
-	case n == 0:
+	case !allowEmpty && n == 0:
 		return 0, nil
 	default:
 		n++
@@ -59,3 +59,5 @@ func BinaryUnmarshal(b []byte, unmarshal func([]byte) error) error {
 	}
 	return unmarshal(b[1:])
 }
+
+const ExplicitEmptyBinaryProtoSize = 1


### PR DESCRIPTION
* rmsbox.Reference can distinguish a missing reference and an explicit empty value by a new SetExact() method