### PR TITLE
NOISSUE: exclude cloud test from longtest

### DIFF
--- a/ledger-core/testutils/cloud/controller.go
+++ b/ledger-core/testutils/cloud/controller.go
@@ -54,7 +54,7 @@ type NetworkController struct {
 	leavers []reference.Global
 }
 
-func (n NetworkController) nodeCount() int {
+func (n *NetworkController) nodeCount() int {
 	n.lock.RLock()
 	defer n.lock.RUnlock()
 

--- a/ledger-core/testutils/cloud/controller_test.go
+++ b/ledger-core/testutils/cloud/controller_test.go
@@ -3,7 +3,7 @@
 // This material is licensed under the Insolar License version 1.0,
 // available at https://github.com/insolar/assured-ledger/blob/master/LICENSE.md.
 
-// +build slowtest
+// +build slowtest,!longtest
 
 package cloud_test
 


### PR DESCRIPTION
cloud test should not be run with big count, because ports are not freed immediately 